### PR TITLE
TGC-1292 - New config based allowlist endpoint

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -30,6 +30,8 @@ services:
       GRANTS_CONFIG_BROKER_AUTH_TOKEN: '${GRANTS_CONFIG_BROKER_AUTH_TOKEN:-config-broker-auth-token}'
       GRANTS_CONFIG_BROKER_ENCRYPTION_KEY: '${GRANTS_CONFIG_BROKER_ENCRYPTION_KEY:-config-broker-encryption-key}'
       CONFIG_INGEST_SQS_QUEUE_URL: http://localstack:4566/000000000000/grants_ui_backend__sqs__config_updates
+      GRANTS_UI_BASE_URL: '${GRANTS_UI_BASE_URL:-http://localhost:3000}'
+      ENCRYPTED_AUTH_JWT_SECRET: ${ENCRYPTED_AUTH_JWT_SECRET:-allowlist-jwt-secret}
     networks:
       - grants-ui-net
     volumes:

--- a/http/grants-ui-backend.http
+++ b/http/grants-ui-backend.http
@@ -11,6 +11,7 @@
 @grantCode = example-grant-with-auth
 @grantVersion = 1.0.1
 @sbi = 1234567891
+@crn = 1234567890
 @userId = test-user-2
 
 ### Health check
@@ -89,6 +90,17 @@ Content-Type: application/json
 # @name getSubmissions
 GET {{backendBaseUrl}}/submissions?sbi={{sbi}}&grantCode={{grantCode}}
 Authorization: Bearer {{backendAuthToken}}
+
+
+### --- Allowlist ---
+
+### Resolve grants accessible to a user
+# @name getAllowedGrants
+# encryptedAuthToken is a JWT signed with ENCRYPTED_AUTH_JWT_SECRET containing crn and sbi.
+# Run `npm run generate:env` to regenerate it.
+GET {{backendBaseUrl}}/allowlist/grants
+Authorization: Bearer {{backendAuthToken}}
+x-encrypted-auth: {{encryptedAuthToken}}
 
 
 ### --- Release lock ---

--- a/migrations/config/20260612000000-create-allowlist-indexes.js
+++ b/migrations/config/20260612000000-create-allowlist-indexes.js
@@ -1,0 +1,38 @@
+const COLLECTION = 'config__allowlist_entries'
+
+/**
+ * @param db {import('mongodb').Db}
+ * @returns {Promise<void>}
+ */
+export const up = async (db) => {
+  // Covered index for findGrantCodesByEntry(type, value, env).
+  // distinct('grantCode', { type, value, env }) reads only the index — no
+  // document fetches — at any list size.
+  await db.collection(COLLECTION).createIndex({ type: 1, value: 1, env: 1, grantCode: 1 })
+
+  // Covered index for findGrantCodesWithAllowlist(env).
+  // distinct('grantCode', { env }) reads only the index.
+  await db.collection(COLLECTION).createIndex({ env: 1, grantCode: 1 })
+
+  // Index for replaceAllowlistEntries: deleteMany({ grantCode })
+  await db.collection(COLLECTION).createIndex({ grantCode: 1 })
+}
+
+/**
+ * @param db {import('mongodb').Db}
+ * @returns {Promise<void>}
+ */
+export const down = async (db) => {
+  await db
+    .collection(COLLECTION)
+    .dropIndex({ type: 1, value: 1, env: 1, grantCode: 1 })
+    .catch(() => {})
+  await db
+    .collection(COLLECTION)
+    .dropIndex({ env: 1, grantCode: 1 })
+    .catch(() => {})
+  await db
+    .collection(COLLECTION)
+    .dropIndex({ grantCode: 1 })
+    .catch(() => {})
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -475,9 +475,23 @@ paths:
         Returns the list of active grants the user identified by `crn` and `sbi`
         is permitted to access. The user identity is read from the `x-encrypted-auth`
         JWT header (signed with `ENCRYPTED_AUTH_JWT_SECRET`), which must contain `crn`
-        and `sbi` claims. Grants with no allowlist entries are open to all users.
-        Grants with entries require the user to appear in both the CRN and SBI lists
-        for the current environment.
+        and `sbi` claims.
+
+        Access rules (evaluated per environment):
+        - Grants with **no allowlist entries** are **closed to all users**.
+        - Grants with `allowAll: true` in their `allowlist.yaml` are **open to all users**.
+        - Otherwise the user must appear in **both** the CRN and SBI lists.
+
+        The `allowlist.yaml` format (per environment, per grant config):
+        ```yaml
+        dev:
+          allowAll: true        # open to everyone in dev
+        test:
+          crns:
+            - '1234567890'
+          sbis:
+            - '123456789'
+        ```
       parameters:
         - in: header
           name: x-encrypted-auth

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -30,6 +30,8 @@ tags:
     description: Manage persisted grant application state
   - name: Submissions
     description: Record grant application submissions
+  - name: Allowlist
+    description: Resolve grants a user is permitted to access
 
 components:
   securitySchemes:
@@ -143,6 +145,30 @@ components:
       description: A list of submissions matching the provided filters
       items:
         $ref: '#/components/schemas/Submission'
+    Grant:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Grant code / slug
+        title:
+          type: string
+          description: Human-readable grant title
+        description:
+          type: ['string', 'null']
+          description: Short description of the grant
+        url:
+          type: ['string', 'null']
+          description: URL to the grant application, or null if not configured
+      required: [code, title, description, url]
+    AllowlistGrantsResponse:
+      type: object
+      properties:
+        grants:
+          type: array
+          items:
+            $ref: '#/components/schemas/Grant'
+      required: [grants]
     StatePatchRequest:
       type: object
       additionalProperties: false
@@ -437,6 +463,49 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Failed to retrieve submissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /allowlist/grants:
+    get:
+      tags: [Allowlist]
+      summary: Resolve grants accessible to a user
+      description: |
+        Returns the list of active grants the user identified by `crn` and `sbi`
+        is permitted to access. The user identity is read from the `x-encrypted-auth`
+        JWT header (signed with `ENCRYPTED_AUTH_JWT_SECRET`), which must contain `crn`
+        and `sbi` claims. Grants with no allowlist entries are open to all users.
+        Grants with entries require the user to appear in both the CRN and SBI lists
+        for the current environment.
+      parameters:
+        - in: header
+          name: x-encrypted-auth
+          required: true
+          schema:
+            type: string
+          description: JWT signed with ENCRYPTED_AUTH_JWT_SECRET containing crn and sbi claims
+      responses:
+        '200':
+          description: List of grants the user may access
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllowlistGrantsResponse'
+              example:
+                grants:
+                  - code: woodland
+                    title: Woodland Creation Grant
+                    description: Support for creating new woodland areas
+                    url: http://localhost:3000/woodland
+        '401':
+          description: Missing or invalid bearer token, or missing crn/sbi in JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Failed to resolve allowlist
           content:
             application/json:
               schema:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13315,24 +13315,23 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
+      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4397,33 +4397,6 @@
         }
       }
     },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/address/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
@@ -9372,34 +9345,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/hapi-pulse/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/hapi-pulse/node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/hapi-pulse/node_modules/joi": {
-      "version": "17.9.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
-      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "node_modules/has-bigints": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,8 @@
         "node-fetch": "3.3.2",
         "pino": "10.3.1",
         "pino-pretty": "13.1.3",
-        "testcontainers": "11.14.0",
-        "undici": "8.3.0"
+        "testcontainers": "12.0.3",
+        "undici": "8.5.0"
       },
       "devDependencies": {
         "@babel/core": "7.29.7",
@@ -2467,8 +2467,7 @@
     "node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
-      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -2706,7 +2705,6 @@
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
       "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -2719,7 +2717,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
       "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -2737,7 +2734,6 @@
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
       "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -3790,7 +3786,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -4215,32 +4210,27 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
       }
@@ -4248,32 +4238,27 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="
     },
     "node_modules/@sentry-internal/tracing": {
       "version": "7.120.4",
@@ -6572,7 +6557,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -6597,7 +6581,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -6607,7 +6590,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -6989,8 +6971,7 @@
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -7511,7 +7492,6 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
       "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.1",
         "readable-stream": "^3.5.0",
@@ -7526,7 +7506,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7537,28 +7516,25 @@
       }
     },
     "node_modules/dockerode": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.12.tgz",
-      "integrity": "sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==",
-      "license": "Apache-2.0",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.0.tgz",
+      "integrity": "sha512-C52mvJ+7lcyhWNfrzVfFsbTrBfy/ezE9FGEYLpu17FUeBcCkxERk9nN7uDl/478ynDiQ4U+5DbQC2vENHkVEtQ==",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
         "@grpc/grpc-js": "^1.11.1",
         "@grpc/proto-loader": "^0.7.13",
         "docker-modem": "^5.0.7",
         "protobufjs": "^7.3.2",
-        "tar-fs": "^2.1.4",
-        "uuid": "^10.0.0"
+        "tar-fs": "^2.1.4"
       },
       "engines": {
-        "node": ">= 8.0"
+        "node": ">= 14.17"
       }
     },
     "node_modules/dockerode/node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7572,7 +7548,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -7584,7 +7559,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -8912,8 +8886,7 @@
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -11359,8 +11332,7 @@
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT"
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -11427,8 +11399,7 @@
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -11689,8 +11660,7 @@
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mongodb": {
       "version": "7.2.0",
@@ -14340,8 +14310,7 @@
     "node_modules/split-ca": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
-      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
-      "license": "ISC"
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -14822,10 +14791,9 @@
       }
     },
     "node_modules/testcontainers": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.14.0.tgz",
-      "integrity": "sha512-r9pniwv/iwzyHaI7gwAvAm4Y+IvjJg3vBWdjrUCaDMc2AXIr4jKbq7jJO18Mw2ybs73pZy1Aj7p/4RVBGMRWjg==",
-      "license": "MIT",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-12.0.3.tgz",
+      "integrity": "sha512-6vfiL9CWIX0rWhTJitzrzHcv4Q/sUfUdBV12jMz6HZ58Lz6ZtXVecO6jljd1O3ookEWQHNICiYoYNEPpDLzuRw==",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
         "@types/dockerode": "^4.0.1",
@@ -14834,23 +14802,14 @@
         "byline": "^5.0.0",
         "debug": "^4.4.3",
         "docker-compose": "^1.4.2",
-        "dockerode": "^4.0.10",
+        "dockerode": "^5.0.0",
         "get-port": "^7.2.0",
         "proper-lockfile": "^4.1.2",
         "properties-reader": "^3.0.1",
         "ssh-remote-port-forward": "^1.0.4",
         "tar-fs": "^3.1.2",
-        "tmp": "^0.2.5",
-        "undici": "^7.24.5"
-      }
-    },
-    "node_modules/testcontainers/node_modules/undici": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
-      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
+        "tmp": "^0.2.7",
+        "undici": "^8.3.0"
       }
     },
     "node_modules/text-decoder": {
@@ -15206,10 +15165,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
-      "license": "MIT",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "engines": {
         "node": ">=22.19.0"
       }
@@ -15380,19 +15338,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3943,9 +3943,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3960,9 +3957,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3977,9 +3971,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3994,9 +3985,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4700,9 +4688,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4721,9 +4706,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4742,9 +4724,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4763,9 +4742,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4784,9 +4760,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4805,9 +4778,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5526,9 +5496,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5543,9 +5510,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5560,9 +5524,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5577,9 +5538,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5594,9 +5552,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5611,9 +5566,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5628,9 +5580,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5645,9 +5594,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5662,9 +5608,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5679,9 +5622,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15014,10 +14954,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
-      "license": "MIT",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "engines": {
         "node": ">=14.14"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "joi": "18.2.1",
         "js-yaml": "4.2.0",
         "jsonwebtoken": "9.0.3",
+        "lru-cache": "11.5.1",
         "migrate-mongo": "14.0.7",
         "mongodb": "7.2.0",
         "node-fetch": "3.3.2",
@@ -799,6 +800,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
@@ -11548,13 +11559,12 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "undici": "8.3.0"
   },
   "overrides": {
+    "joi": "18.2.1",
     "protobufjs": "7.5.8",
     "tmp": "0.2.7",
     "underscore": "1.13.8",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "overrides": {
     "joi": "18.2.1",
-    "protobufjs": "7.5.8",
+    "protobufjs": "7.6.3",
     "tmp": "0.2.7",
     "underscore": "1.13.8",
     "uuid": "14.0.0"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "overrides": {
     "protobufjs": "7.5.8",
-    "tmp": "0.2.6",
+    "tmp": "0.2.7",
     "underscore": "1.13.8",
     "uuid": "14.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "node-fetch": "3.3.2",
     "pino": "10.3.1",
     "pino-pretty": "13.1.3",
-    "testcontainers": "11.14.0",
-    "undici": "8.3.0"
+    "testcontainers": "12.0.3",
+    "undici": "8.5.0"
   },
   "overrides": {
     "joi": "18.2.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "joi": "18.2.1",
     "js-yaml": "4.2.0",
     "jsonwebtoken": "9.0.3",
+    "lru-cache": "11.5.1",
     "migrate-mongo": "14.0.7",
     "mongodb": "7.2.0",
     "node-fetch": "3.3.2",

--- a/scripts/generatePrivateEnv.js
+++ b/scripts/generatePrivateEnv.js
@@ -5,10 +5,11 @@
  * http/http-client.private.env.json (local section only).
  *
  * Variables are sourced from:
- *   - http/grants-ui-backend.http  (grantCode, grantVersion, sbi, userId)
+ *   - http/grants-ui-backend.http  (grantCode, grantVersion, sbi, crn, userId)
  *   - compose.yml                  (APPLICATION_LOCK_TOKEN_SECRET,
  *                                   GRANTS_UI_BACKEND_AUTH_TOKEN,
- *                                   GRANTS_UI_BACKEND_ENCRYPTION_KEY)
+ *                                   GRANTS_UI_BACKEND_ENCRYPTION_KEY,
+ *                                   ENCRYPTED_AUTH_JWT_SECRET)
  *
  * No .env file required.
  */
@@ -37,6 +38,7 @@ function parseHttpVar(name) {
 const grantCode = parseHttpVar('grantCode')
 const grantVersion = parseHttpVar('grantVersion')
 const sbi = parseHttpVar('sbi')
+const crn = parseHttpVar('crn')
 const userId = parseHttpVar('userId')
 
 // ---------------------------------------------------------------------------
@@ -56,6 +58,7 @@ function parseComposeEnv(name) {
 const lockSecret = parseComposeEnv('APPLICATION_LOCK_TOKEN_SECRET')
 const authToken = parseComposeEnv('GRANTS_UI_BACKEND_AUTH_TOKEN')
 const encryptionKey = parseComposeEnv('GRANTS_UI_BACKEND_ENCRYPTION_KEY')
+const encryptedAuthJwtSecret = parseComposeEnv('ENCRYPTED_AUTH_JWT_SECRET')
 const configBrokerAuthToken = parseComposeEnv('GRANTS_CONFIG_BROKER_AUTH_TOKEN')
 const configBrokerEncryptionKey = parseComposeEnv('GRANTS_CONFIG_BROKER_ENCRYPTION_KEY')
 
@@ -65,6 +68,9 @@ const configBrokerEncryptionKey = parseComposeEnv('GRANTS_CONFIG_BROKER_ENCRYPTI
 const backendAuthToken = generateAuthToken(authToken, encryptionKey)
 const applicationLockOwnerToken = generateLockOwnerToken(lockSecret, userId, sbi, grantCode, grantVersion)
 const applicationLockReleaseToken = generateLockReleaseToken(lockSecret, userId)
+
+const { default: jwt } = await import('jsonwebtoken')
+const encryptedAuthToken = jwt.sign({ crn, sbi }, encryptedAuthJwtSecret)
 
 // ---------------------------------------------------------------------------
 // 4. Write results into the local section of http-client.private.env.json
@@ -84,6 +90,7 @@ if (!privateEnv.local) privateEnv.local = {}
 privateEnv.local.backendAuthToken = backendAuthToken
 privateEnv.local.applicationLockOwnerToken = applicationLockOwnerToken
 privateEnv.local.applicationLockReleaseToken = applicationLockReleaseToken
+privateEnv.local.encryptedAuthToken = encryptedAuthToken
 
 if (!privateEnv.local.configBrokerAuthToken) {
   privateEnv.local.configBrokerAuthToken = configBrokerAuthToken
@@ -102,6 +109,7 @@ console.log('✓ http/http-client.private.env.json (local) updated:')
 console.log('  backendAuthToken')
 console.log('  applicationLockOwnerToken')
 console.log('  applicationLockReleaseToken')
+console.log('  encryptedAuthToken')
 console.log('  configBrokerAuthToken (if absent)')
 console.log('  configBrokerEncryptionKey (if absent)')
 console.log('  xApiKey (if absent)')

--- a/src/common/helpers/logging/log-codes.js
+++ b/src/common/helpers/logging/log-codes.js
@@ -240,7 +240,7 @@ export const LogCodes = {
     },
     GRANTS_BAD_REQUEST: {
       level: 'warn',
-      messageFunc: ({ errorMessage }) => `POST /allowlist/grants, validation failed: ${errorMessage}`
+      messageFunc: ({ errorMessage }) => `GET /allowlist/grants, validation failed: ${errorMessage}`
     },
     STARTUP_PULL_FAILED: {
       level: 'error',

--- a/src/common/helpers/logging/log-codes.js
+++ b/src/common/helpers/logging/log-codes.js
@@ -222,6 +222,32 @@ export const LogCodes = {
         `SQS consumer shutdown error | errorName=${errorName} | errorMessage=${errorMessage} | stack=${stack}`
     }
   },
+  ALLOWLIST: {
+    INGEST_UPSERTED: {
+      level: 'info',
+      messageFunc: ({ grantCode, version, status, entryCount }) =>
+        `Upserted allowlist entries | grantCode=${grantCode} | version=${version} | status=${status} | entryCount=${entryCount}`
+    },
+    INGEST_CLEARED: {
+      level: 'debug',
+      messageFunc: ({ grantCode, version }) =>
+        `No allowlist.yaml in manifest, clearing entries to open grant to all | grantCode=${grantCode} | version=${version}`
+    },
+    GRANTS_CHECKED: {
+      level: 'info',
+      messageFunc: ({ crn, sbi, env, matchedCount }) =>
+        `Allowlist grants checked | crn=${crn} | sbi=${sbi} | env=${env} | matchedCount=${matchedCount}`
+    },
+    GRANTS_BAD_REQUEST: {
+      level: 'warn',
+      messageFunc: ({ errorMessage }) => `POST /allowlist/grants, validation failed: ${errorMessage}`
+    },
+    STARTUP_PULL_FAILED: {
+      level: 'error',
+      messageFunc: ({ grantCode, errorName, errorMessage, stack }) =>
+        `Failed to ingest allowlist during startup pull | grantCode=${grantCode} | errorName=${errorName} | errorMessage=${errorMessage} | stack=${stack}`
+    }
+  },
   MIGRATIONS: {
     APPLIED: {
       level: 'info',

--- a/src/common/helpers/logging/log-codes.js
+++ b/src/common/helpers/logging/log-codes.js
@@ -234,11 +234,11 @@ export const LogCodes = {
         `No allowlist.yaml in manifest, clearing entries to open grant to all | grantCode=${grantCode} | version=${version}`
     },
     GRANTS_CHECKED: {
-      level: 'info',
+      level: 'debug',
       messageFunc: ({ crn, sbi, env, matchedCount }) =>
         `Allowlist grants checked | crn=${crn} | sbi=${sbi} | env=${env} | matchedCount=${matchedCount}`
     },
-    GRANTS_BAD_REQUEST: {
+    GRANTS_UNAUTHORIZED: {
       level: 'warn',
       messageFunc: ({ errorMessage }) => `GET /allowlist/grants, validation failed: ${errorMessage}`
     },

--- a/src/common/helpers/logging/log-codes.test.js
+++ b/src/common/helpers/logging/log-codes.test.js
@@ -441,6 +441,43 @@ describe('LogCodes', () => {
     })
   })
 
+  describe('ALLOWLIST log codes', () => {
+    it.each([
+      [
+        'INGEST_UPSERTED',
+        'info',
+        { grantCode: 'woodland', version: '1.0.0', status: 'active', entryCount: 42 },
+        'Upserted allowlist entries | grantCode=woodland | version=1.0.0 | status=active | entryCount=42'
+      ],
+      [
+        'INGEST_CLEARED',
+        'debug',
+        { grantCode: 'woodland', version: '1.0.0' },
+        'No allowlist.yaml in manifest, clearing entries to open grant to all | grantCode=woodland | version=1.0.0'
+      ],
+      [
+        'GRANTS_CHECKED',
+        'info',
+        { crn: '1234567890', sbi: '123456789', env: 'local', matchedCount: 2 },
+        'Allowlist grants checked | crn=1234567890 | sbi=123456789 | env=local | matchedCount=2'
+      ],
+      [
+        'GRANTS_BAD_REQUEST',
+        'warn',
+        { errorMessage: 'crn and sbi are required' },
+        'POST /allowlist/grants, validation failed: crn and sbi are required'
+      ],
+      [
+        'STARTUP_PULL_FAILED',
+        'error',
+        { grantCode: 'woodland', errorName: 'Error', errorMessage: 'broker down', stack: 'Error: broker down' },
+        'Failed to ingest allowlist during startup pull | grantCode=woodland | errorName=Error | errorMessage=broker down | stack=Error: broker down'
+      ]
+    ])('should have valid %s log code', (logCodeName, expectedLevel, testParams, expectedMessage) => {
+      assertLogCode('ALLOWLIST', logCodeName, expectedLevel, testParams, expectedMessage)
+    })
+  })
+
   describe('validateLogCodes', () => {
     it('should validate all log codes without throwing', () => {
       expect(() => validateLogCodes(LogCodes)).not.toThrow()

--- a/src/common/helpers/logging/log-codes.test.js
+++ b/src/common/helpers/logging/log-codes.test.js
@@ -465,7 +465,7 @@ describe('LogCodes', () => {
         'GRANTS_BAD_REQUEST',
         'warn',
         { errorMessage: 'crn and sbi are required' },
-        'POST /allowlist/grants, validation failed: crn and sbi are required'
+        'GET /allowlist/grants, validation failed: crn and sbi are required'
       ],
       [
         'STARTUP_PULL_FAILED',

--- a/src/common/helpers/logging/log-codes.test.js
+++ b/src/common/helpers/logging/log-codes.test.js
@@ -457,12 +457,12 @@ describe('LogCodes', () => {
       ],
       [
         'GRANTS_CHECKED',
-        'info',
+        'debug',
         { crn: '1234567890', sbi: '123456789', env: 'local', matchedCount: 2 },
         'Allowlist grants checked | crn=1234567890 | sbi=123456789 | env=local | matchedCount=2'
       ],
       [
-        'GRANTS_BAD_REQUEST',
+        'GRANTS_UNAUTHORIZED',
         'warn',
         { errorMessage: 'crn and sbi are required' },
         'GET /allowlist/grants, validation failed: crn and sbi are required'

--- a/src/common/helpers/s3.js
+++ b/src/common/helpers/s3.js
@@ -1,6 +1,6 @@
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
 import { load as loadYaml } from 'js-yaml'
-import { config } from '../../../config.js'
+import { config } from '../../config.js'
 
 let s3Client
 

--- a/src/common/helpers/s3.test.js
+++ b/src/common/helpers/s3.test.js
@@ -1,7 +1,7 @@
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
 import { load as loadYaml } from 'js-yaml'
-import { config } from '../../../config.js'
-import { getS3Client, getYamlObject, _resetS3ClientForTests } from './s3-client.js'
+import { config } from '../../config.js'
+import { getS3Client, getYamlObject, _resetS3ClientForTests } from './s3.js'
 
 jest.mock('@aws-sdk/client-s3', () => ({
   S3Client: jest.fn(),
@@ -12,7 +12,7 @@ jest.mock('js-yaml', () => ({
   load: jest.fn()
 }))
 
-jest.mock('../../../config.js', () => ({
+jest.mock('../../config.js', () => ({
   config: {
     get: jest.fn()
   }
@@ -23,7 +23,7 @@ const configValues = {
   'aws.endpointUrl': undefined
 }
 
-describe('s3-client', () => {
+describe('s3', () => {
   beforeEach(() => {
     _resetS3ClientForTests()
     config.get.mockImplementation((key) => configValues[key])

--- a/src/config.js
+++ b/src/config.js
@@ -186,6 +186,19 @@ const config = convict({
       env: 'CONFIG_INGEST_SQS_VISIBILITY_TIMEOUT_SECONDS'
     }
   },
+  grantsUiBaseUrl: {
+    doc: 'Base URL of the Grants UI frontend, used to construct grant URLs',
+    format: String,
+    default: '',
+    env: 'GRANTS_UI_BASE_URL'
+  },
+  encryptedAuthJwtSecret: {
+    doc: 'Secret used to verify the x-encrypted-auth JWT sent by grants-ui',
+    format: String,
+    default: '',
+    env: 'ENCRYPTED_AUTH_JWT_SECRET',
+    sensitive: true
+  },
   applicationLock: {
     secret: {
       doc: 'Secret used to verify application lock tokens',

--- a/src/modules/allowlist/allowlist.repository.js
+++ b/src/modules/allowlist/allowlist.repository.js
@@ -1,0 +1,100 @@
+/**
+ * Allowlist module — MongoDB data access.
+ *
+ * One document per (grantCode, env, type, value). Normalised so every lookup
+ * is O(log n) via a covered compound index — MongoDB never touches the
+ * documents themselves, only the index — regardless of list size.
+ *
+ * Index: { type, value, env, grantCode }
+ *   - type  : low cardinality prefix ('crn' | 'sbi') — narrows the scan quickly
+ *   - value : the actual CRN/SBI string — highly selective
+ *   - env   : environment key — further narrows
+ *   - grantCode : included last so distinct('grantCode', …) is fully covered
+ *
+ * The same index (prefix { env, grantCode }) also covers findGrantCodesWithAllowlist.
+ * A second index { env, grantCode } is added for that query alone.
+ */
+
+/**
+ * @typedef {'crn' | 'sbi'} AllowlistEntryType
+ *
+ * @typedef {Object} AllowlistEntry
+ * @property {string} grantCode
+ * @property {string} env
+ * @property {AllowlistEntryType} type
+ * @property {string} value
+ * @property {Date} updatedAt
+ */
+
+const COLLECTION = 'config__allowlist_entries'
+
+/** Batch size for insertMany to stay well under the 16MB BSON doc limit */
+const INSERT_BATCH_SIZE = 5_000
+
+/** @type {import('mongodb').Db} */
+let allowlistDb
+
+/**
+ * Initialises the repository with the config database instance.
+ *
+ * @param {import('mongodb').Db} db
+ */
+export function initAllowlistRepository(db) {
+  allowlistDb = db
+}
+
+/**
+ * Atomically replaces all allowlist entries for a grant within a single
+ * transaction: deletes existing entries then bulk-inserts the new set in
+ * batches of INSERT_BATCH_SIZE.
+ *
+ * @param {string} grantCode
+ * @param {AllowlistEntry[]} entries
+ * @returns {Promise<void>}
+ */
+export async function replaceAllowlistEntries(grantCode, entries) {
+  const collection = allowlistDb.collection(COLLECTION)
+  const session = allowlistDb.client.startSession()
+
+  try {
+    await session.withTransaction(async () => {
+      await collection.deleteMany({ grantCode }, { session })
+
+      for (let i = 0; i < entries.length; i += INSERT_BATCH_SIZE) {
+        await collection.insertMany(entries.slice(i, i + INSERT_BATCH_SIZE), { ordered: false, session })
+      }
+    })
+  } finally {
+    await session.endSession()
+  }
+}
+
+/**
+ * Returns all distinct grantCodes that have at least one entry matching the
+ * given type, value and env.
+ *
+ * Backed by the covered index { type, value, env, grantCode } — no document
+ * reads, index-only scan.
+ *
+ * @param {AllowlistEntryType} type
+ * @param {string} value
+ * @param {string} env
+ * @returns {Promise<string[]>}
+ */
+export async function findGrantCodesByEntry(type, value, env) {
+  return allowlistDb.collection(COLLECTION).distinct('grantCode', { type, value, env })
+}
+
+/**
+ * Returns all distinct grantCodes that have any entries for the given env.
+ * Used to distinguish "grant has no allowlist" (allow all) from "grant has an
+ * allowlist but this user is not on it" (deny).
+ *
+ * Backed by the covered index { env, grantCode } — index-only scan.
+ *
+ * @param {string} env
+ * @returns {Promise<string[]>}
+ */
+export async function findGrantCodesWithAllowlist(env) {
+  return allowlistDb.collection(COLLECTION).distinct('grantCode', { env })
+}

--- a/src/modules/allowlist/allowlist.repository.js
+++ b/src/modules/allowlist/allowlist.repository.js
@@ -86,15 +86,23 @@ export async function findGrantCodesByEntry(type, value, env) {
 }
 
 /**
- * Returns all distinct grantCodes that have any entries for the given env.
- * Used to distinguish "grant has no allowlist" (allow all) from "grant has an
- * allowlist but this user is not on it" (deny).
+ * Returns a Map of grantCode → { allowAll: boolean } for every grant that has
+ * any allowlist entries for the given env. Grants absent from the map have no
+ * allowlist and are closed to all users.
  *
- * Backed by the covered index { env, grantCode } — index-only scan.
+ * Single aggregation pipeline — replaces the two separate distinct() queries.
  *
  * @param {string} env
- * @returns {Promise<string[]>}
+ * @returns {Promise<Map<string, { allowAll: boolean }>>}
  */
 export async function findGrantCodesWithAllowlist(env) {
-  return allowlistDb.collection(COLLECTION).distinct('grantCode', { env })
+  const rows = await allowlistDb
+    .collection(COLLECTION)
+    .aggregate([
+      { $match: { env } },
+      { $group: { _id: '$grantCode', allowAll: { $max: { $eq: ['$type', 'allowAll'] } } } }
+    ])
+    .toArray()
+
+  return new Map(rows.map(({ _id, allowAll }) => [_id, { allowAll }]))
 }

--- a/src/modules/allowlist/allowlist.repository.test.js
+++ b/src/modules/allowlist/allowlist.repository.test.js
@@ -78,33 +78,50 @@ describe('allowlist.repository', () => {
   })
 
   describe('findGrantCodesWithAllowlist', () => {
-    test('returns all grant codes that have any entries for the env', async () => {
+    test('returns a Map of grantCode to meta for grants with entries in the env', async () => {
       await db
         .collection(COLLECTION)
         .insertMany([
-          makeEntry({ grantCode: 'woodland', env: 'local' }),
+          makeEntry({ grantCode: 'woodland', env: 'local', type: 'crn', value: '111' }),
           makeEntry({ grantCode: 'woodland', env: 'local', type: 'sbi', value: '999' }),
-          makeEntry({ grantCode: 'farm-payments', env: 'local' })
+          makeEntry({ grantCode: 'farm-payments', env: 'local', type: 'crn', value: '222' })
         ])
 
       const result = await findGrantCodesWithAllowlist('local')
 
-      expect(result).toHaveLength(2)
-      expect(result).toEqual(expect.arrayContaining(['woodland', 'farm-payments']))
+      expect(result).toBeInstanceOf(Map)
+      expect(result.size).toBe(2)
+      expect(result.get('woodland')).toEqual({ allowAll: false })
+      expect(result.get('farm-payments')).toEqual({ allowAll: false })
     })
 
-    test('does not return grant codes from a different environment', async () => {
+    test('sets allowAll: true for grants with an allowAll entry', async () => {
+      await db
+        .collection(COLLECTION)
+        .insertMany([
+          makeEntry({ grantCode: 'woodland', type: 'allowAll', value: 'true', env: 'local' }),
+          makeEntry({ grantCode: 'farm-payments', type: 'crn', value: '111', env: 'local' })
+        ])
+
+      const result = await findGrantCodesWithAllowlist('local')
+
+      expect(result.get('woodland')).toEqual({ allowAll: true })
+      expect(result.get('farm-payments')).toEqual({ allowAll: false })
+    })
+
+    test('does not include grants from a different environment', async () => {
       await db.collection(COLLECTION).insertOne(makeEntry({ grantCode: 'woodland', env: 'production' }))
 
       const result = await findGrantCodesWithAllowlist('local')
 
-      expect(result).toEqual([])
+      expect(result.size).toBe(0)
     })
 
-    test('returns empty array when collection is empty', async () => {
+    test('returns empty Map when collection is empty', async () => {
       const result = await findGrantCodesWithAllowlist('local')
 
-      expect(result).toEqual([])
+      expect(result).toBeInstanceOf(Map)
+      expect(result.size).toBe(0)
     })
   })
 })

--- a/src/modules/allowlist/allowlist.repository.test.js
+++ b/src/modules/allowlist/allowlist.repository.test.js
@@ -1,0 +1,110 @@
+import { MongoClient } from 'mongodb'
+import { initAllowlistRepository, findGrantCodesByEntry, findGrantCodesWithAllowlist } from './allowlist.repository.js'
+import { up as createAllowlistIndexes } from '~/migrations/config/20260612000000-create-allowlist-indexes.js'
+
+const COLLECTION = 'config__allowlist_entries'
+
+const makeEntry = (overrides = {}) => ({
+  grantCode: 'woodland',
+  env: 'local',
+  type: 'crn',
+  value: '1234567890',
+  updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+  ...overrides
+})
+
+describe('allowlist.repository', () => {
+  let connection
+  let db
+
+  beforeAll(async () => {
+    const uri = new URL(process.env.MONGO_URI)
+    uri.searchParams.set('retryWrites', 'false')
+    connection = await MongoClient.connect(uri.toString())
+    db = connection.db('grants-ui-allowlist-test')
+    await createAllowlistIndexes(db)
+    initAllowlistRepository(db)
+  })
+
+  afterAll(async () => {
+    await db
+      .collection(COLLECTION)
+      .drop()
+      .catch(() => {})
+    await connection.close()
+  })
+
+  beforeEach(async () => {
+    await db.collection(COLLECTION).deleteMany({})
+  })
+
+  describe('findGrantCodesByEntry', () => {
+    test('returns grant codes where the user appears in the given type list', async () => {
+      await db
+        .collection(COLLECTION)
+        .insertMany([
+          makeEntry({ grantCode: 'woodland', type: 'crn', value: '111', env: 'local' }),
+          makeEntry({ grantCode: 'farm-payments', type: 'crn', value: '111', env: 'local' }),
+          makeEntry({ grantCode: 'other-grant', type: 'crn', value: '999', env: 'local' })
+        ])
+
+      const result = await findGrantCodesByEntry('crn', '111', 'local')
+
+      expect(result).toHaveLength(2)
+      expect(result).toEqual(expect.arrayContaining(['woodland', 'farm-payments']))
+    })
+
+    test('does not match entries from a different environment', async () => {
+      await db.collection(COLLECTION).insertOne(makeEntry({ type: 'crn', value: '111', env: 'production' }))
+
+      const result = await findGrantCodesByEntry('crn', '111', 'local')
+
+      expect(result).toEqual([])
+    })
+
+    test('does not match entries of a different type', async () => {
+      await db.collection(COLLECTION).insertOne(makeEntry({ type: 'sbi', value: '111', env: 'local' }))
+
+      const result = await findGrantCodesByEntry('crn', '111', 'local')
+
+      expect(result).toEqual([])
+    })
+
+    test('returns empty array when no entries match', async () => {
+      const result = await findGrantCodesByEntry('crn', 'unknown', 'local')
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('findGrantCodesWithAllowlist', () => {
+    test('returns all grant codes that have any entries for the env', async () => {
+      await db
+        .collection(COLLECTION)
+        .insertMany([
+          makeEntry({ grantCode: 'woodland', env: 'local' }),
+          makeEntry({ grantCode: 'woodland', env: 'local', type: 'sbi', value: '999' }),
+          makeEntry({ grantCode: 'farm-payments', env: 'local' })
+        ])
+
+      const result = await findGrantCodesWithAllowlist('local')
+
+      expect(result).toHaveLength(2)
+      expect(result).toEqual(expect.arrayContaining(['woodland', 'farm-payments']))
+    })
+
+    test('does not return grant codes from a different environment', async () => {
+      await db.collection(COLLECTION).insertOne(makeEntry({ grantCode: 'woodland', env: 'production' }))
+
+      const result = await findGrantCodesWithAllowlist('local')
+
+      expect(result).toEqual([])
+    })
+
+    test('returns empty array when collection is empty', async () => {
+      const result = await findGrantCodesWithAllowlist('local')
+
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/src/modules/allowlist/allowlist.routes.js
+++ b/src/modules/allowlist/allowlist.routes.js
@@ -1,0 +1,23 @@
+import Boom from '@hapi/boom'
+import { StatusCodes } from 'http-status-codes'
+import { resolveAllowedGrants } from './allowlist.service.js'
+import { log, LogCodes } from '../../common/helpers/logging/log.js'
+
+export const allowlistGrants = {
+  method: 'GET',
+  path: '/allowlist/grants',
+  options: {
+    auth: 'bearer'
+  },
+  handler: async (request, h) => {
+    const { crn, sbi } = request.auth.credentials
+
+    if (!crn || !sbi) {
+      log(LogCodes.ALLOWLIST.GRANTS_BAD_REQUEST, { errorMessage: 'crn and sbi missing from token' })
+      throw Boom.unauthorized('crn and sbi are required in the x-encrypted-auth token')
+    }
+
+    const grants = await resolveAllowedGrants(crn, sbi)
+    return h.response({ grants }).code(StatusCodes.OK)
+  }
+}

--- a/src/modules/allowlist/allowlist.routes.js
+++ b/src/modules/allowlist/allowlist.routes.js
@@ -13,7 +13,7 @@ export const allowlistGrants = {
     const { crn, sbi } = request.auth.credentials
 
     if (!crn || !sbi) {
-      log(LogCodes.ALLOWLIST.GRANTS_BAD_REQUEST, { errorMessage: 'crn and sbi missing from token' })
+      log(LogCodes.ALLOWLIST.GRANTS_UNAUTHORIZED, { errorMessage: 'crn and sbi missing from token' })
       throw Boom.unauthorized('crn and sbi are required in the x-encrypted-auth token')
     }
 

--- a/src/modules/allowlist/allowlist.routes.test.js
+++ b/src/modules/allowlist/allowlist.routes.test.js
@@ -69,7 +69,7 @@ describe('allowlistGrants route', () => {
 
     test('logs a warning when crn or sbi is missing', async () => {
       await expect(allowlistGrants.handler(mockRequest(undefined, undefined), mockH)).rejects.toThrow()
-      expect(log).toHaveBeenCalledWith(LogCodes.ALLOWLIST.GRANTS_BAD_REQUEST, expect.any(Object))
+      expect(log).toHaveBeenCalledWith(LogCodes.ALLOWLIST.GRANTS_UNAUTHORIZED, expect.any(Object))
     })
   })
 

--- a/src/modules/allowlist/allowlist.routes.test.js
+++ b/src/modules/allowlist/allowlist.routes.test.js
@@ -1,0 +1,86 @@
+import Boom from '@hapi/boom'
+import { allowlistGrants } from './allowlist.routes.js'
+import { resolveAllowedGrants } from './allowlist.service.js'
+import { log, LogCodes } from '../../common/helpers/logging/log.js'
+
+jest.mock('./allowlist.service.js', () => ({
+  resolveAllowedGrants: jest.fn()
+}))
+
+jest.mock('../../common/helpers/logging/log.js', () => {
+  const { LogCodes } = jest.requireActual('../../common/helpers/logging/log-codes.js')
+  return { log: jest.fn(), LogCodes }
+})
+
+const mockRequest = (crn, sbi) => ({ auth: { credentials: { crn, sbi } } })
+
+describe('allowlistGrants route', () => {
+  let mockH
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockH = {
+      response: jest.fn().mockReturnThis(),
+      code: jest.fn().mockReturnThis()
+    }
+  })
+
+  describe('handler', () => {
+    test('returns 200 with matched grants', async () => {
+      const grants = [
+        {
+          code: 'woodland',
+          title: 'Woodland Management Plan',
+          description: 'A description.',
+          url: 'https://grants-ui.dev.cdp-int.defra.cloud/woodland'
+        }
+      ]
+      resolveAllowedGrants.mockResolvedValue(grants)
+
+      await allowlistGrants.handler(mockRequest('1234567890', '123456789'), mockH)
+
+      expect(resolveAllowedGrants).toHaveBeenCalledWith('1234567890', '123456789')
+      expect(mockH.response).toHaveBeenCalledWith({ grants })
+      expect(mockH.code).toHaveBeenCalledWith(200)
+    })
+
+    test('returns 200 with empty grants array when user has no allowed grants', async () => {
+      resolveAllowedGrants.mockResolvedValue([])
+
+      await allowlistGrants.handler(mockRequest('1234567890', '123456789'), mockH)
+
+      expect(mockH.response).toHaveBeenCalledWith({ grants: [] })
+      expect(mockH.code).toHaveBeenCalledWith(200)
+    })
+
+    test('throws 401 when crn is missing from token', async () => {
+      await expect(allowlistGrants.handler(mockRequest(undefined, '123456789'), mockH)).rejects.toThrow(
+        Boom.unauthorized().constructor
+      )
+      expect(resolveAllowedGrants).not.toHaveBeenCalled()
+    })
+
+    test('throws 401 when sbi is missing from token', async () => {
+      await expect(allowlistGrants.handler(mockRequest('1234567890', undefined), mockH)).rejects.toThrow(
+        Boom.unauthorized().constructor
+      )
+      expect(resolveAllowedGrants).not.toHaveBeenCalled()
+    })
+
+    test('logs a warning when crn or sbi is missing', async () => {
+      await expect(allowlistGrants.handler(mockRequest(undefined, undefined), mockH)).rejects.toThrow()
+      expect(log).toHaveBeenCalledWith(LogCodes.ALLOWLIST.GRANTS_BAD_REQUEST, expect.any(Object))
+    })
+  })
+
+  describe('route config', () => {
+    test('requires bearer auth', () => {
+      expect(allowlistGrants.options.auth).toBe('bearer')
+    })
+
+    test('is a GET to /allowlist/grants', () => {
+      expect(allowlistGrants.method).toBe('GET')
+      expect(allowlistGrants.path).toBe('/allowlist/grants')
+    })
+  })
+})

--- a/src/modules/allowlist/allowlist.service.js
+++ b/src/modules/allowlist/allowlist.service.js
@@ -25,7 +25,9 @@ export const allowlistCache = new LRUCache({ max: 500, ttl: 2 * 60 * 1000 })
 export async function resolveAllowedGrants(crn, sbi) {
   const cacheKey = `${crn}:${sbi}`
   const cached = allowlistCache.get(cacheKey)
-  if (cached) return cached
+  if (cached) {
+    return cached
+  }
 
   const env = config.get('cdpEnvironment')
   const allActiveGrants = await getAllActiveGrants()
@@ -41,7 +43,9 @@ export async function resolveAllowedGrants(crn, sbi) {
   const restrictedSet = new Set(grantsWithAllowlist)
 
   const allowed = allActiveGrants.filter(({ grantCode }) => {
-    if (!restrictedSet.has(grantCode)) return true
+    if (!restrictedSet.has(grantCode)) {
+      return true
+    }
     return crnSet.has(grantCode) && sbiSet.has(grantCode)
   })
 

--- a/src/modules/allowlist/allowlist.service.js
+++ b/src/modules/allowlist/allowlist.service.js
@@ -1,0 +1,61 @@
+import { LRUCache } from 'lru-cache'
+import { config } from '../../config.js'
+import { findGrantCodesByEntry, findGrantCodesWithAllowlist } from './allowlist.repository.js'
+import { getAllActiveGrants } from '../config/config.repository.js'
+import { log, LogCodes } from '../../common/helpers/logging/log.js'
+
+export const allowlistCache = new LRUCache({ max: 500, ttl: 2 * 60 * 1000 })
+
+/**
+ * @typedef {{ grantCode: string, title: string, description: string|null, urls: Record<string,string>|null }} GrantMeta
+ */
+
+/**
+ * Returns the grants accessible to a user based on the allowlist for the
+ * current environment, with title, description and resolved url.
+ *
+ * Rules:
+ * - A user must appear in BOTH the crn list AND the sbi list for a grant.
+ * - Grants with no allowlist entries for the current env are open to all users.
+ *
+ * @param {string} crn
+ * @param {string} sbi
+ * @returns {Promise<Array<{ code: string, title: string, description: string|null, url: string|null }>>}
+ */
+export async function resolveAllowedGrants(crn, sbi) {
+  const cacheKey = `${crn}:${sbi}`
+  const cached = allowlistCache.get(cacheKey)
+  if (cached) return cached
+
+  const env = config.get('cdpEnvironment')
+  const allActiveGrants = await getAllActiveGrants()
+
+  const [crnMatches, sbiMatches, grantsWithAllowlist] = await Promise.all([
+    findGrantCodesByEntry('crn', String(crn), env),
+    findGrantCodesByEntry('sbi', String(sbi), env),
+    findGrantCodesWithAllowlist(env)
+  ])
+
+  const crnSet = new Set(crnMatches)
+  const sbiSet = new Set(sbiMatches)
+  const restrictedSet = new Set(grantsWithAllowlist)
+
+  const allowed = allActiveGrants.filter(({ grantCode }) => {
+    if (!restrictedSet.has(grantCode)) return true
+    return crnSet.has(grantCode) && sbiSet.has(grantCode)
+  })
+
+  log(LogCodes.ALLOWLIST.GRANTS_CHECKED, { crn, sbi, env, matchedCount: allowed.length })
+
+  const grantsUiBaseUrl = config.get('grantsUiBaseUrl')
+
+  const result = allowed.map(({ grantCode, title, description }) => ({
+    code: grantCode,
+    title,
+    description,
+    url: grantsUiBaseUrl ? `${grantsUiBaseUrl}/${grantCode}` : null
+  }))
+
+  allowlistCache.set(cacheKey, result)
+  return result
+}

--- a/src/modules/allowlist/allowlist.service.js
+++ b/src/modules/allowlist/allowlist.service.js
@@ -30,9 +30,9 @@ export async function resolveAllowedGrants(crn, sbi) {
   }
 
   const env = config.get('cdpEnvironment')
-  const allActiveGrants = await getAllActiveGrants()
 
-  const [crnMatches, sbiMatches, grantsWithAllowlist] = await Promise.all([
+  const [allActiveGrants, crnMatches, sbiMatches, grantsWithAllowlist] = await Promise.all([
+    getAllActiveGrants(),
     findGrantCodesByEntry('crn', String(crn), env),
     findGrantCodesByEntry('sbi', String(sbi), env),
     findGrantCodesWithAllowlist(env)

--- a/src/modules/allowlist/allowlist.service.js
+++ b/src/modules/allowlist/allowlist.service.js
@@ -15,8 +15,9 @@ export const allowlistCache = new LRUCache({ max: 500, ttl: 2 * 60 * 1000 })
  * current environment, with title, description and resolved url.
  *
  * Rules:
- * - A user must appear in BOTH the crn list AND the sbi list for a grant.
- * - Grants with no allowlist entries for the current env are open to all users.
+ * - Grants with no allowlist entries for the current env are closed to all users.
+ * - Grants with allowAll: true are open to all users.
+ * - Otherwise a user must appear in BOTH the crn list AND the sbi list.
  *
  * @param {string} crn
  * @param {string} sbi
@@ -40,10 +41,13 @@ export async function resolveAllowedGrants(crn, sbi) {
 
   const crnSet = new Set(crnMatches)
   const sbiSet = new Set(sbiMatches)
-  const restrictedSet = new Set(grantsWithAllowlist)
 
   const allowed = allActiveGrants.filter(({ grantCode }) => {
-    if (!restrictedSet.has(grantCode)) {
+    const allowlist = grantsWithAllowlist.get(grantCode)
+    if (!allowlist) {
+      return false
+    }
+    if (allowlist.allowAll) {
       return true
     }
     return crnSet.has(grantCode) && sbiSet.has(grantCode)

--- a/src/modules/allowlist/allowlist.service.test.js
+++ b/src/modules/allowlist/allowlist.service.test.js
@@ -1,0 +1,190 @@
+import { resolveAllowedGrants, allowlistCache } from './allowlist.service.js'
+import { findGrantCodesByEntry, findGrantCodesWithAllowlist } from './allowlist.repository.js'
+import { getAllActiveGrants } from '../config/config.repository.js'
+import { config } from '../../config.js'
+
+jest.mock('./allowlist.repository.js', () => ({
+  findGrantCodesByEntry: jest.fn(),
+  findGrantCodesWithAllowlist: jest.fn()
+}))
+
+jest.mock('../config/config.repository.js', () => ({
+  getAllActiveGrants: jest.fn()
+}))
+
+jest.mock('../../config.js', () => ({
+  config: { get: jest.fn() }
+}))
+
+jest.mock('../../common/helpers/logging/log.js', () => {
+  const { LogCodes } = jest.requireActual('../../common/helpers/logging/log-codes.js')
+  return { log: jest.fn(), LogCodes }
+})
+
+const woodland = { grantCode: 'woodland', title: 'Woodland Management Plan', description: 'A description.' }
+const farmPayments = { grantCode: 'farm-payments', title: 'Farm Payments', description: null }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  allowlistCache.clear()
+  config.get.mockImplementation((key) => {
+    if (key === 'cdpEnvironment') return 'dev'
+    if (key === 'grantsUiBaseUrl') return 'https://grants-ui.dev.cdp-int.defra.cloud'
+    return null
+  })
+})
+
+describe('resolveAllowedGrants', () => {
+  test('returns all active grants for a grant with no allowlist entries', async () => {
+    getAllActiveGrants.mockResolvedValue([woodland, farmPayments])
+    findGrantCodesByEntry.mockResolvedValue([])
+    findGrantCodesWithAllowlist.mockResolvedValue([])
+
+    const result = await resolveAllowedGrants('1234567890', '123456789')
+
+    expect(result).toEqual([
+      {
+        code: 'woodland',
+        title: 'Woodland Management Plan',
+        description: 'A description.',
+        url: 'https://grants-ui.dev.cdp-int.defra.cloud/woodland'
+      },
+      {
+        code: 'farm-payments',
+        title: 'Farm Payments',
+        description: null,
+        url: 'https://grants-ui.dev.cdp-int.defra.cloud/farm-payments'
+      }
+    ])
+  })
+
+  test('returns only grants where user is in both crn and sbi lists', async () => {
+    getAllActiveGrants.mockResolvedValue([woodland, farmPayments])
+    findGrantCodesByEntry.mockImplementation((type) => {
+      if (type === 'crn') return Promise.resolve(['woodland'])
+      if (type === 'sbi') return Promise.resolve(['woodland'])
+    })
+    findGrantCodesWithAllowlist.mockResolvedValue(['woodland', 'farm-payments'])
+
+    const result = await resolveAllowedGrants('1234567890', '123456789')
+
+    expect(result).toHaveLength(1)
+    expect(result[0].code).toBe('woodland')
+  })
+
+  test('denies access when user is in crn list but not sbi list', async () => {
+    getAllActiveGrants.mockResolvedValue([woodland])
+    findGrantCodesByEntry.mockImplementation((type) => {
+      if (type === 'crn') return Promise.resolve(['woodland'])
+      if (type === 'sbi') return Promise.resolve([])
+    })
+    findGrantCodesWithAllowlist.mockResolvedValue(['woodland'])
+
+    const result = await resolveAllowedGrants('1234567890', '000000000')
+
+    expect(result).toEqual([])
+  })
+
+  test('denies access when user is in sbi list but not crn list', async () => {
+    getAllActiveGrants.mockResolvedValue([woodland])
+    findGrantCodesByEntry.mockImplementation((type) => {
+      if (type === 'crn') return Promise.resolve([])
+      if (type === 'sbi') return Promise.resolve(['woodland'])
+    })
+    findGrantCodesWithAllowlist.mockResolvedValue(['woodland'])
+
+    const result = await resolveAllowedGrants('0000000000', '123456789')
+
+    expect(result).toEqual([])
+  })
+
+  test('allows access to grant with no allowlist even when other grants restrict', async () => {
+    getAllActiveGrants.mockResolvedValue([woodland, farmPayments])
+    findGrantCodesByEntry.mockResolvedValue([])
+    findGrantCodesWithAllowlist.mockResolvedValue(['woodland'])
+
+    const result = await resolveAllowedGrants('0000000000', '000000000')
+
+    expect(result).toHaveLength(1)
+    expect(result[0].code).toBe('farm-payments')
+  })
+
+  test('returns empty array when user is not on any allowlist and all grants are restricted', async () => {
+    getAllActiveGrants.mockResolvedValue([woodland])
+    findGrantCodesByEntry.mockResolvedValue([])
+    findGrantCodesWithAllowlist.mockResolvedValue(['woodland'])
+
+    const result = await resolveAllowedGrants('0000000000', '000000000')
+
+    expect(result).toEqual([])
+  })
+
+  test('returns empty array when there are no active grants', async () => {
+    getAllActiveGrants.mockResolvedValue([])
+    findGrantCodesByEntry.mockResolvedValue([])
+    findGrantCodesWithAllowlist.mockResolvedValue([])
+
+    const result = await resolveAllowedGrants('1234567890', '123456789')
+
+    expect(result).toEqual([])
+  })
+
+  test('constructs url from GRANTS_UI_BASE_URL and grantCode', async () => {
+    config.get.mockImplementation((key) => {
+      if (key === 'cdpEnvironment') return 'prod'
+      if (key === 'grantsUiBaseUrl') return 'https://grants.defra.gov.uk'
+      return null
+    })
+    getAllActiveGrants.mockResolvedValue([woodland])
+    findGrantCodesByEntry.mockResolvedValue([])
+    findGrantCodesWithAllowlist.mockResolvedValue([])
+
+    const result = await resolveAllowedGrants('1234567890', '123456789')
+
+    expect(result[0].url).toBe('https://grants.defra.gov.uk/woodland')
+  })
+
+  test('returns null url when GRANTS_UI_BASE_URL is not set', async () => {
+    config.get.mockImplementation((key) => {
+      if (key === 'cdpEnvironment') return 'dev'
+      if (key === 'grantsUiBaseUrl') return ''
+      return null
+    })
+    getAllActiveGrants.mockResolvedValue([woodland])
+    findGrantCodesByEntry.mockResolvedValue([])
+    findGrantCodesWithAllowlist.mockResolvedValue([])
+
+    const result = await resolveAllowedGrants('1234567890', '123456789')
+
+    expect(result[0].url).toBeNull()
+  })
+
+  test('returns cached result on repeated call without hitting the db', async () => {
+    getAllActiveGrants.mockResolvedValue([woodland])
+    findGrantCodesByEntry.mockResolvedValue([])
+    findGrantCodesWithAllowlist.mockResolvedValue([])
+
+    const first = await resolveAllowedGrants('1234567890', '123456789')
+    const second = await resolveAllowedGrants('1234567890', '123456789')
+
+    expect(second).toEqual(first)
+    expect(getAllActiveGrants).toHaveBeenCalledTimes(1)
+  })
+
+  test('queries with the current cdpEnvironment', async () => {
+    config.get.mockImplementation((key) => {
+      if (key === 'cdpEnvironment') return 'prod'
+      if (key === 'grantsUiBaseUrl') return 'https://grants.defra.gov.uk'
+      return null
+    })
+    getAllActiveGrants.mockResolvedValue([woodland])
+    findGrantCodesByEntry.mockResolvedValue([])
+    findGrantCodesWithAllowlist.mockResolvedValue([])
+
+    await resolveAllowedGrants('1234567890', '123456789')
+
+    expect(findGrantCodesByEntry).toHaveBeenCalledWith('crn', '1234567890', 'prod')
+    expect(findGrantCodesByEntry).toHaveBeenCalledWith('sbi', '123456789', 'prod')
+    expect(findGrantCodesWithAllowlist).toHaveBeenCalledWith('prod')
+  })
+})

--- a/src/modules/allowlist/allowlist.service.test.js
+++ b/src/modules/allowlist/allowlist.service.test.js
@@ -32,30 +32,17 @@ beforeEach(() => {
     if (key === 'grantsUiBaseUrl') return 'https://grants-ui.dev.cdp-int.defra.cloud'
     return null
   })
+  findGrantCodesWithAllowlist.mockResolvedValue(new Map())
 })
 
 describe('resolveAllowedGrants', () => {
-  test('returns all active grants for a grant with no allowlist entries', async () => {
+  test('denies access to a grant with no allowlist entries (closed by default)', async () => {
     getAllActiveGrants.mockResolvedValue([woodland, farmPayments])
     findGrantCodesByEntry.mockResolvedValue([])
-    findGrantCodesWithAllowlist.mockResolvedValue([])
 
     const result = await resolveAllowedGrants('1234567890', '123456789')
 
-    expect(result).toEqual([
-      {
-        code: 'woodland',
-        title: 'Woodland Management Plan',
-        description: 'A description.',
-        url: 'https://grants-ui.dev.cdp-int.defra.cloud/woodland'
-      },
-      {
-        code: 'farm-payments',
-        title: 'Farm Payments',
-        description: null,
-        url: 'https://grants-ui.dev.cdp-int.defra.cloud/farm-payments'
-      }
-    ])
+    expect(result).toEqual([])
   })
 
   test('returns only grants where user is in both crn and sbi lists', async () => {
@@ -64,7 +51,12 @@ describe('resolveAllowedGrants', () => {
       if (type === 'crn') return Promise.resolve(['woodland'])
       if (type === 'sbi') return Promise.resolve(['woodland'])
     })
-    findGrantCodesWithAllowlist.mockResolvedValue(['woodland', 'farm-payments'])
+    findGrantCodesWithAllowlist.mockResolvedValue(
+      new Map([
+        ['woodland', { allowAll: false }],
+        ['farm-payments', { allowAll: false }]
+      ])
+    )
 
     const result = await resolveAllowedGrants('1234567890', '123456789')
 
@@ -78,7 +70,7 @@ describe('resolveAllowedGrants', () => {
       if (type === 'crn') return Promise.resolve(['woodland'])
       if (type === 'sbi') return Promise.resolve([])
     })
-    findGrantCodesWithAllowlist.mockResolvedValue(['woodland'])
+    findGrantCodesWithAllowlist.mockResolvedValue(new Map([['woodland', { allowAll: false }]]))
 
     const result = await resolveAllowedGrants('1234567890', '000000000')
 
@@ -91,28 +83,26 @@ describe('resolveAllowedGrants', () => {
       if (type === 'crn') return Promise.resolve([])
       if (type === 'sbi') return Promise.resolve(['woodland'])
     })
-    findGrantCodesWithAllowlist.mockResolvedValue(['woodland'])
+    findGrantCodesWithAllowlist.mockResolvedValue(new Map([['woodland', { allowAll: false }]]))
 
     const result = await resolveAllowedGrants('0000000000', '123456789')
 
     expect(result).toEqual([])
   })
 
-  test('allows access to grant with no allowlist even when other grants restrict', async () => {
+  test('denies access to all grants when none have allowlist entries', async () => {
     getAllActiveGrants.mockResolvedValue([woodland, farmPayments])
     findGrantCodesByEntry.mockResolvedValue([])
-    findGrantCodesWithAllowlist.mockResolvedValue(['woodland'])
 
     const result = await resolveAllowedGrants('0000000000', '000000000')
 
-    expect(result).toHaveLength(1)
-    expect(result[0].code).toBe('farm-payments')
+    expect(result).toEqual([])
   })
 
   test('returns empty array when user is not on any allowlist and all grants are restricted', async () => {
     getAllActiveGrants.mockResolvedValue([woodland])
     findGrantCodesByEntry.mockResolvedValue([])
-    findGrantCodesWithAllowlist.mockResolvedValue(['woodland'])
+    findGrantCodesWithAllowlist.mockResolvedValue(new Map([['woodland', { allowAll: false }]]))
 
     const result = await resolveAllowedGrants('0000000000', '000000000')
 
@@ -122,11 +112,37 @@ describe('resolveAllowedGrants', () => {
   test('returns empty array when there are no active grants', async () => {
     getAllActiveGrants.mockResolvedValue([])
     findGrantCodesByEntry.mockResolvedValue([])
-    findGrantCodesWithAllowlist.mockResolvedValue([])
 
     const result = await resolveAllowedGrants('1234567890', '123456789')
 
     expect(result).toEqual([])
+  })
+
+  test('allows all users when allowAll is set for the grant', async () => {
+    getAllActiveGrants.mockResolvedValue([woodland])
+    findGrantCodesByEntry.mockResolvedValue([])
+    findGrantCodesWithAllowlist.mockResolvedValue(new Map([['woodland', { allowAll: true }]]))
+
+    const result = await resolveAllowedGrants('9999999999', '999999999')
+
+    expect(result).toHaveLength(1)
+    expect(result[0].code).toBe('woodland')
+  })
+
+  test('allowAll only applies per grant — other grants still check crn/sbi', async () => {
+    getAllActiveGrants.mockResolvedValue([woodland, farmPayments])
+    findGrantCodesByEntry.mockResolvedValue([])
+    findGrantCodesWithAllowlist.mockResolvedValue(
+      new Map([
+        ['woodland', { allowAll: true }],
+        ['farm-payments', { allowAll: false }]
+      ])
+    )
+
+    const result = await resolveAllowedGrants('9999999999', '999999999')
+
+    expect(result).toHaveLength(1)
+    expect(result[0].code).toBe('woodland')
   })
 
   test('constructs url from GRANTS_UI_BASE_URL and grantCode', async () => {
@@ -136,8 +152,11 @@ describe('resolveAllowedGrants', () => {
       return null
     })
     getAllActiveGrants.mockResolvedValue([woodland])
-    findGrantCodesByEntry.mockResolvedValue([])
-    findGrantCodesWithAllowlist.mockResolvedValue([])
+    findGrantCodesByEntry.mockImplementation((type) => {
+      if (type === 'crn') return Promise.resolve(['woodland'])
+      if (type === 'sbi') return Promise.resolve(['woodland'])
+    })
+    findGrantCodesWithAllowlist.mockResolvedValue(new Map([['woodland', { allowAll: false }]]))
 
     const result = await resolveAllowedGrants('1234567890', '123456789')
 
@@ -151,8 +170,11 @@ describe('resolveAllowedGrants', () => {
       return null
     })
     getAllActiveGrants.mockResolvedValue([woodland])
-    findGrantCodesByEntry.mockResolvedValue([])
-    findGrantCodesWithAllowlist.mockResolvedValue([])
+    findGrantCodesByEntry.mockImplementation((type) => {
+      if (type === 'crn') return Promise.resolve(['woodland'])
+      if (type === 'sbi') return Promise.resolve(['woodland'])
+    })
+    findGrantCodesWithAllowlist.mockResolvedValue(new Map([['woodland', { allowAll: false }]]))
 
     const result = await resolveAllowedGrants('1234567890', '123456789')
 
@@ -162,7 +184,6 @@ describe('resolveAllowedGrants', () => {
   test('returns cached result on repeated call without hitting the db', async () => {
     getAllActiveGrants.mockResolvedValue([woodland])
     findGrantCodesByEntry.mockResolvedValue([])
-    findGrantCodesWithAllowlist.mockResolvedValue([])
 
     const first = await resolveAllowedGrants('1234567890', '123456789')
     const second = await resolveAllowedGrants('1234567890', '123456789')
@@ -179,7 +200,6 @@ describe('resolveAllowedGrants', () => {
     })
     getAllActiveGrants.mockResolvedValue([woodland])
     findGrantCodesByEntry.mockResolvedValue([])
-    findGrantCodesWithAllowlist.mockResolvedValue([])
 
     await resolveAllowedGrants('1234567890', '123456789')
 

--- a/src/modules/allowlist/allowlist.transform.js
+++ b/src/modules/allowlist/allowlist.transform.js
@@ -1,0 +1,32 @@
+/**
+ * Flattens a parsed allowlist.yaml body into individual entry documents,
+ * one per (grantCode, env, type, value).
+ *
+ * allowlist.yaml structure:
+ *   dev:
+ *     crns: ['111', '222']
+ *     sbis: ['333', '444']
+ *   prod:
+ *     crns: [...]
+ *     sbis: [...]
+ *
+ * @param {string} grantCode
+ * @param {Record<string, { crns?: string[], sbis?: string[] }>} allowlist - parsed YAML body
+ * @returns {import('./allowlist.repository.js').AllowlistEntry[]}
+ */
+export function buildAllowlistEntries(grantCode, allowlist) {
+  const entries = []
+  const updatedAt = new Date()
+
+  for (const [env, lists] of Object.entries(allowlist ?? {})) {
+    for (const crn of lists?.crns ?? []) {
+      // String() guards against YAML parsers auto-coercing numeric-looking values to numbers
+      entries.push({ grantCode, env, type: 'crn', value: String(crn), updatedAt })
+    }
+    for (const sbi of lists?.sbis ?? []) {
+      entries.push({ grantCode, env, type: 'sbi', value: String(sbi), updatedAt })
+    }
+  }
+
+  return entries
+}

--- a/src/modules/allowlist/allowlist.transform.js
+++ b/src/modules/allowlist/allowlist.transform.js
@@ -4,6 +4,8 @@
  *
  * allowlist.yaml structure:
  *   dev:
+ *     allowAll: true          # everyone is allowed; crns/sbis are ignored
+ *   test:
  *     crns: ['111', '222']
  *     sbis: ['333', '444']
  *   prod:
@@ -11,7 +13,7 @@
  *     sbis: [...]
  *
  * @param {string} grantCode
- * @param {Record<string, { crns?: string[], sbis?: string[] }>} allowlist - parsed YAML body
+ * @param {Record<string, { allowAll?: boolean, crns?: string[], sbis?: string[] }>} allowlist - parsed YAML body
  * @returns {import('./allowlist.repository.js').AllowlistEntry[]}
  */
 export function buildAllowlistEntries(grantCode, allowlist) {
@@ -19,11 +21,15 @@ export function buildAllowlistEntries(grantCode, allowlist) {
   const updatedAt = new Date()
 
   for (const [env, lists] of Object.entries(allowlist ?? {})) {
-    for (const crn of lists?.crns ?? []) {
+    if (lists?.allowAll === true) {
+      entries.push({ grantCode, env, type: 'allowAll', value: 'true', updatedAt })
+      continue
+    }
+    for (const crn of Array.isArray(lists?.crns) ? lists.crns : []) {
       // String() guards against YAML parsers auto-coercing numeric-looking values to numbers
       entries.push({ grantCode, env, type: 'crn', value: String(crn), updatedAt })
     }
-    for (const sbi of lists?.sbis ?? []) {
+    for (const sbi of Array.isArray(lists?.sbis) ? lists.sbis : []) {
       entries.push({ grantCode, env, type: 'sbi', value: String(sbi), updatedAt })
     }
   }

--- a/src/modules/allowlist/allowlist.transform.test.js
+++ b/src/modules/allowlist/allowlist.transform.test.js
@@ -1,0 +1,82 @@
+import { buildAllowlistEntries } from './allowlist.transform.js'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('buildAllowlistEntries', () => {
+  test('returns empty array when allowlist is null', () => {
+    expect(buildAllowlistEntries('woodland', null)).toEqual([])
+  })
+
+  test('returns empty array when allowlist is undefined', () => {
+    expect(buildAllowlistEntries('woodland', undefined)).toEqual([])
+  })
+
+  test('returns empty array when allowlist is empty object', () => {
+    expect(buildAllowlistEntries('woodland', {})).toEqual([])
+  })
+
+  test('flattens crns and sbis into individual entry documents', () => {
+    const allowlist = {
+      dev: {
+        crns: ['1111111111', '2222222222'],
+        sbis: ['123456789']
+      }
+    }
+
+    const entries = buildAllowlistEntries('woodland', allowlist)
+
+    expect(entries).toHaveLength(3)
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ grantCode: 'woodland', env: 'dev', type: 'crn', value: '1111111111' }),
+        expect.objectContaining({ grantCode: 'woodland', env: 'dev', type: 'crn', value: '2222222222' }),
+        expect.objectContaining({ grantCode: 'woodland', env: 'dev', type: 'sbi', value: '123456789' })
+      ])
+    )
+  })
+
+  test('handles multiple environments', () => {
+    const allowlist = {
+      dev: { crns: ['111'], sbis: [] },
+      prod: { crns: [], sbis: ['999'] }
+    }
+
+    const entries = buildAllowlistEntries('woodland', allowlist)
+
+    expect(entries).toHaveLength(2)
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ env: 'dev', type: 'crn', value: '111' }),
+        expect.objectContaining({ env: 'prod', type: 'sbi', value: '999' })
+      ])
+    )
+  })
+
+  test('coerces numeric values to strings', () => {
+    const allowlist = { dev: { crns: [1234567890], sbis: [123456789] } }
+
+    const entries = buildAllowlistEntries('woodland', allowlist)
+
+    expect(entries[0].value).toBe('1234567890')
+    expect(entries[1].value).toBe('123456789')
+  })
+
+  test('handles missing crns or sbis gracefully', () => {
+    const allowlist = { dev: { crns: ['111'] } }
+
+    const entries = buildAllowlistEntries('woodland', allowlist)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ type: 'crn', value: '111' })
+  })
+
+  test('each entry has an updatedAt date', () => {
+    const allowlist = { dev: { crns: ['111'] } }
+
+    const entries = buildAllowlistEntries('woodland', allowlist)
+
+    expect(entries[0].updatedAt).toBeInstanceOf(Date)
+  })
+})

--- a/src/modules/allowlist/allowlist.transform.test.js
+++ b/src/modules/allowlist/allowlist.transform.test.js
@@ -72,6 +72,14 @@ describe('buildAllowlistEntries', () => {
     expect(entries[0]).toMatchObject({ type: 'crn', value: '111' })
   })
 
+  test('handles null env value gracefully', () => {
+    const allowlist = { dev: null }
+
+    const entries = buildAllowlistEntries('woodland', allowlist)
+
+    expect(entries).toEqual([])
+  })
+
   test('each entry has an updatedAt date', () => {
     const allowlist = { dev: { crns: ['111'] } }
 

--- a/src/modules/allowlist/allowlist.transform.test.js
+++ b/src/modules/allowlist/allowlist.transform.test.js
@@ -72,12 +72,47 @@ describe('buildAllowlistEntries', () => {
     expect(entries[0]).toMatchObject({ type: 'crn', value: '111' })
   })
 
+  test('ignores crns or sbis that are not arrays', () => {
+    const allowlist = { dev: { crns: '1234567890', sbis: 123456789 } }
+
+    const entries = buildAllowlistEntries('woodland', allowlist)
+
+    expect(entries).toEqual([])
+  })
+
   test('handles null env value gracefully', () => {
     const allowlist = { dev: null }
 
     const entries = buildAllowlistEntries('woodland', allowlist)
 
     expect(entries).toEqual([])
+  })
+
+  test('emits a single allowAll entry when allowAll is true, ignoring crns/sbis', () => {
+    const allowlist = {
+      dev: { allowAll: true, crns: ['111'], sbis: ['222'] }
+    }
+
+    const entries = buildAllowlistEntries('woodland', allowlist)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ grantCode: 'woodland', env: 'dev', type: 'allowAll', value: 'true' })
+  })
+
+  test('processes crns/sbis normally when allowAll is false', () => {
+    const allowlist = {
+      dev: { allowAll: false, crns: ['111'], sbis: ['222'] }
+    }
+
+    const entries = buildAllowlistEntries('woodland', allowlist)
+
+    expect(entries).toHaveLength(2)
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'crn', value: '111' }),
+        expect.objectContaining({ type: 'sbi', value: '222' })
+      ])
+    )
   })
 
   test('each entry has an updatedAt date', () => {

--- a/src/modules/allowlist/ingest-allowlist.js
+++ b/src/modules/allowlist/ingest-allowlist.js
@@ -1,0 +1,34 @@
+import { replaceAllowlistEntries } from './allowlist.repository.js'
+import { buildAllowlistEntries } from './allowlist.transform.js'
+import { getYamlObject } from '../config/ingest/s3-client.js'
+import { log, LogCodes } from '../../common/helpers/logging/log.js'
+
+/**
+ * Fetches allowlist.yaml from S3 for the given grant version and replaces all
+ * allowlist entries for that grant in Mongo.
+ *
+ * Should only be called for active versions — callers are responsible for
+ * checking status before calling.
+ *
+ * @param {Object} params
+ * @param {string} params.grantCode
+ * @param {string} params.version
+ * @param {string} params.bucket
+ * @param {string[]} params.manifest
+ * @returns {Promise<void>}
+ */
+export async function ingestAllowlist({ grantCode, version, bucket, manifest }) {
+  const allowlistPath = manifest.find((path) => path === `${grantCode}/${version}/allowlist.yaml`)
+
+  if (!allowlistPath) {
+    log(LogCodes.ALLOWLIST.INGEST_CLEARED, { grantCode, version })
+    await replaceAllowlistEntries(grantCode, [])
+    return
+  }
+
+  const allowlist = await getYamlObject(bucket, allowlistPath)
+  const entries = buildAllowlistEntries(grantCode, allowlist)
+  await replaceAllowlistEntries(grantCode, entries)
+
+  log(LogCodes.ALLOWLIST.INGEST_UPSERTED, { grantCode, version, status: 'active', entryCount: entries.length })
+}

--- a/src/modules/allowlist/ingest-allowlist.js
+++ b/src/modules/allowlist/ingest-allowlist.js
@@ -1,6 +1,6 @@
 import { replaceAllowlistEntries } from './allowlist.repository.js'
 import { buildAllowlistEntries } from './allowlist.transform.js'
-import { getYamlObject } from '../config/ingest/s3-client.js'
+import { getYamlObject } from '../../common/helpers/s3.js'
 import { log, LogCodes } from '../../common/helpers/logging/log.js'
 
 /**
@@ -18,7 +18,7 @@ import { log, LogCodes } from '../../common/helpers/logging/log.js'
  * @returns {Promise<void>}
  */
 export async function ingestAllowlist({ grantCode, version, bucket, manifest }) {
-  const allowlistPath = manifest.find((path) => path === `${grantCode}/${version}/allowlist.yaml`)
+  const allowlistPath = manifest.find((path) => path === `${grantCode}/${version}/grants-ui/allowlist.yaml`)
 
   if (!allowlistPath) {
     log(LogCodes.ALLOWLIST.INGEST_CLEARED, { grantCode, version })

--- a/src/modules/allowlist/ingest-allowlist.test.js
+++ b/src/modules/allowlist/ingest-allowlist.test.js
@@ -1,0 +1,65 @@
+import { ingestAllowlist } from './ingest-allowlist.js'
+import { replaceAllowlistEntries } from './allowlist.repository.js'
+import { buildAllowlistEntries } from './allowlist.transform.js'
+import { getYamlObject } from '../config/ingest/s3-client.js'
+
+jest.mock('./allowlist.repository.js', () => ({
+  replaceAllowlistEntries: jest.fn()
+}))
+
+jest.mock('./allowlist.transform.js', () => ({
+  buildAllowlistEntries: jest.fn()
+}))
+
+jest.mock('../config/ingest/s3-client.js', () => ({
+  getYamlObject: jest.fn()
+}))
+
+jest.mock('../../common/helpers/logging/log.js', () => {
+  const actual = jest.requireActual('../../common/helpers/logging/log.js')
+  return { ...actual, log: jest.fn() }
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('ingestAllowlist', () => {
+  const baseParams = {
+    grantCode: 'woodland',
+    version: '1.0.0',
+    bucket: 'my-bucket',
+    manifest: ['woodland/1.0.0/woodland.yaml', 'woodland/1.0.0/allowlist.yaml']
+  }
+
+  test('fetches and ingests allowlist when allowlist.yaml is in manifest', async () => {
+    const definition = { dev: { crns: ['111'], sbis: ['222'] } }
+    const entries = [{ grantCode: 'woodland', env: 'dev', type: 'crn', value: '111' }]
+
+    getYamlObject.mockResolvedValue(definition)
+    buildAllowlistEntries.mockReturnValue(entries)
+
+    await ingestAllowlist(baseParams)
+
+    expect(getYamlObject).toHaveBeenCalledWith('my-bucket', 'woodland/1.0.0/allowlist.yaml')
+    expect(buildAllowlistEntries).toHaveBeenCalledWith('woodland', definition)
+    expect(replaceAllowlistEntries).toHaveBeenCalledWith('woodland', entries)
+  })
+
+  test('clears entries when allowlist.yaml is not in manifest', async () => {
+    await ingestAllowlist({
+      ...baseParams,
+      manifest: ['woodland/1.0.0/woodland.yaml']
+    })
+
+    expect(getYamlObject).not.toHaveBeenCalled()
+    expect(replaceAllowlistEntries).toHaveBeenCalledWith('woodland', [])
+  })
+
+  test('clears entries when manifest is empty', async () => {
+    await ingestAllowlist({ ...baseParams, manifest: [] })
+
+    expect(getYamlObject).not.toHaveBeenCalled()
+    expect(replaceAllowlistEntries).toHaveBeenCalledWith('woodland', [])
+  })
+})

--- a/src/modules/allowlist/ingest-allowlist.test.js
+++ b/src/modules/allowlist/ingest-allowlist.test.js
@@ -1,7 +1,7 @@
 import { ingestAllowlist } from './ingest-allowlist.js'
 import { replaceAllowlistEntries } from './allowlist.repository.js'
 import { buildAllowlistEntries } from './allowlist.transform.js'
-import { getYamlObject } from '../config/ingest/s3-client.js'
+import { getYamlObject } from '../../common/helpers/s3.js'
 
 jest.mock('./allowlist.repository.js', () => ({
   replaceAllowlistEntries: jest.fn()
@@ -11,7 +11,7 @@ jest.mock('./allowlist.transform.js', () => ({
   buildAllowlistEntries: jest.fn()
 }))
 
-jest.mock('../config/ingest/s3-client.js', () => ({
+jest.mock('../../common/helpers/s3.js', () => ({
   getYamlObject: jest.fn()
 }))
 
@@ -29,7 +29,7 @@ describe('ingestAllowlist', () => {
     grantCode: 'woodland',
     version: '1.0.0',
     bucket: 'my-bucket',
-    manifest: ['woodland/1.0.0/woodland.yaml', 'woodland/1.0.0/allowlist.yaml']
+    manifest: ['woodland/1.0.0/grants-ui/woodland.yaml', 'woodland/1.0.0/grants-ui/allowlist.yaml']
   }
 
   test('fetches and ingests allowlist when allowlist.yaml is in manifest', async () => {
@@ -41,7 +41,7 @@ describe('ingestAllowlist', () => {
 
     await ingestAllowlist(baseParams)
 
-    expect(getYamlObject).toHaveBeenCalledWith('my-bucket', 'woodland/1.0.0/allowlist.yaml')
+    expect(getYamlObject).toHaveBeenCalledWith('my-bucket', 'woodland/1.0.0/grants-ui/allowlist.yaml')
     expect(buildAllowlistEntries).toHaveBeenCalledWith('woodland', definition)
     expect(replaceAllowlistEntries).toHaveBeenCalledWith('woodland', entries)
   })
@@ -49,7 +49,7 @@ describe('ingestAllowlist', () => {
   test('clears entries when allowlist.yaml is not in manifest', async () => {
     await ingestAllowlist({
       ...baseParams,
-      manifest: ['woodland/1.0.0/woodland.yaml']
+      manifest: ['woodland/1.0.0/grants-ui/woodland.yaml']
     })
 
     expect(getYamlObject).not.toHaveBeenCalled()

--- a/src/modules/config/config.repository.js
+++ b/src/modules/config/config.repository.js
@@ -8,6 +8,7 @@
  * @property {string} grantCode
  * @property {string} id
  * @property {string} title
+ * @property {string|null} description
  * @property {number} major
  * @property {number} minor
  * @property {number} patch
@@ -104,6 +105,24 @@ export async function updateDefinitionStatus({ grantCode, major, minor, patch, s
     set.updatedAt = updatedAt
   }
   return configDb.collection(COLLECTION).updateOne({ grantCode, major, minor, patch }, { $set: set })
+}
+
+/**
+ * Returns the latest active version metadata for every active grant.
+ * One entry per grant code — the highest semver active version.
+ *
+ * @returns {Promise<Array<{ grantCode: string, title: string, description: string|null }>>}
+ */
+export async function getAllActiveGrants() {
+  return configDb
+    .collection(COLLECTION)
+    .aggregate([
+      { $match: { status: FORM_DEFINITION_STATUS.ACTIVE } },
+      { $sort: { major: -1, minor: -1, patch: -1 } },
+      { $group: { _id: '$grantCode', title: { $first: '$title' }, description: { $first: '$description' } } },
+      { $project: { _id: 0, grantCode: '$_id', title: 1, description: 1 } }
+    ])
+    .toArray()
 }
 
 /**

--- a/src/modules/config/config.repository.test.js
+++ b/src/modules/config/config.repository.test.js
@@ -261,34 +261,32 @@ describe('config.repository', () => {
 
   describe('getAllActiveGrants', () => {
     test('returns one entry per grant with title and description from the latest active version', async () => {
-      await db
-        .collection(COLLECTION)
-        .insertMany([
-          makeDefinition({
-            grantCode: 'woodland',
-            major: 1,
-            minor: 0,
-            patch: 0,
-            title: 'Woodland v1',
-            description: 'Old desc'
-          }),
-          makeDefinition({
-            grantCode: 'woodland',
-            major: 2,
-            minor: 0,
-            patch: 0,
-            title: 'Woodland v2',
-            description: 'New desc'
-          }),
-          makeDefinition({
-            grantCode: 'farm-payments',
-            major: 1,
-            minor: 0,
-            patch: 0,
-            title: 'Farm Payments',
-            description: 'Farm desc'
-          })
-        ])
+      await db.collection(COLLECTION).insertMany([
+        makeDefinition({
+          grantCode: 'woodland',
+          major: 1,
+          minor: 0,
+          patch: 0,
+          title: 'Woodland v1',
+          description: 'Old desc'
+        }),
+        makeDefinition({
+          grantCode: 'woodland',
+          major: 2,
+          minor: 0,
+          patch: 0,
+          title: 'Woodland v2',
+          description: 'New desc'
+        }),
+        makeDefinition({
+          grantCode: 'farm-payments',
+          major: 1,
+          minor: 0,
+          patch: 0,
+          title: 'Farm Payments',
+          description: 'Farm desc'
+        })
+      ])
 
       const result = await getAllActiveGrants()
 
@@ -302,24 +300,22 @@ describe('config.repository', () => {
     })
 
     test('excludes draft versions', async () => {
-      await db
-        .collection(COLLECTION)
-        .insertMany([
-          makeDefinition({
-            grantCode: 'woodland',
-            major: 1,
-            minor: 0,
-            patch: 0,
-            status: FORM_DEFINITION_STATUS.ACTIVE
-          }),
-          makeDefinition({
-            grantCode: 'farm-payments',
-            major: 1,
-            minor: 0,
-            patch: 0,
-            status: FORM_DEFINITION_STATUS.DRAFT
-          })
-        ])
+      await db.collection(COLLECTION).insertMany([
+        makeDefinition({
+          grantCode: 'woodland',
+          major: 1,
+          minor: 0,
+          patch: 0,
+          status: FORM_DEFINITION_STATUS.ACTIVE
+        }),
+        makeDefinition({
+          grantCode: 'farm-payments',
+          major: 1,
+          minor: 0,
+          patch: 0,
+          status: FORM_DEFINITION_STATUS.DRAFT
+        })
+      ])
 
       const result = await getAllActiveGrants()
 

--- a/src/modules/config/config.repository.test.js
+++ b/src/modules/config/config.repository.test.js
@@ -7,7 +7,8 @@ import {
   getDefinition,
   getDefinitionStatuses,
   updateDefinitionStatus,
-  definitionStatusKey
+  definitionStatusKey,
+  getAllActiveGrants
 } from './config.repository.js'
 import { up as createConfigIndexes } from '~/migrations/config/20260603163943-create-indexes.js'
 
@@ -255,6 +256,91 @@ describe('config.repository', () => {
       const result = await getDefinition('farm-payments', 1, 0, 0)
 
       expect(result).toMatchObject({ status: FORM_DEFINITION_STATUS.DRAFT })
+    })
+  })
+
+  describe('getAllActiveGrants', () => {
+    test('returns one entry per grant with title and description from the latest active version', async () => {
+      await db
+        .collection(COLLECTION)
+        .insertMany([
+          makeDefinition({
+            grantCode: 'woodland',
+            major: 1,
+            minor: 0,
+            patch: 0,
+            title: 'Woodland v1',
+            description: 'Old desc'
+          }),
+          makeDefinition({
+            grantCode: 'woodland',
+            major: 2,
+            minor: 0,
+            patch: 0,
+            title: 'Woodland v2',
+            description: 'New desc'
+          }),
+          makeDefinition({
+            grantCode: 'farm-payments',
+            major: 1,
+            minor: 0,
+            patch: 0,
+            title: 'Farm Payments',
+            description: 'Farm desc'
+          })
+        ])
+
+      const result = await getAllActiveGrants()
+
+      expect(result).toHaveLength(2)
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ grantCode: 'woodland', title: 'Woodland v2', description: 'New desc' }),
+          expect.objectContaining({ grantCode: 'farm-payments', title: 'Farm Payments', description: 'Farm desc' })
+        ])
+      )
+    })
+
+    test('excludes draft versions', async () => {
+      await db
+        .collection(COLLECTION)
+        .insertMany([
+          makeDefinition({
+            grantCode: 'woodland',
+            major: 1,
+            minor: 0,
+            patch: 0,
+            status: FORM_DEFINITION_STATUS.ACTIVE
+          }),
+          makeDefinition({
+            grantCode: 'farm-payments',
+            major: 1,
+            minor: 0,
+            patch: 0,
+            status: FORM_DEFINITION_STATUS.DRAFT
+          })
+        ])
+
+      const result = await getAllActiveGrants()
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({ grantCode: 'woodland' })
+    })
+
+    test('returns empty array when there are no active grants', async () => {
+      await db.collection(COLLECTION).insertOne(makeDefinition({ status: FORM_DEFINITION_STATUS.DRAFT }))
+
+      const result = await getAllActiveGrants()
+
+      expect(result).toEqual([])
+    })
+
+    test('does not include _id in the result', async () => {
+      await db.collection(COLLECTION).insertOne(makeDefinition())
+
+      const result = await getAllActiveGrants()
+
+      expect(result[0]).not.toHaveProperty('_id')
     })
   })
 

--- a/src/modules/config/ingest/broker-client.js
+++ b/src/modules/config/ingest/broker-client.js
@@ -106,3 +106,14 @@ export function fetchVersion(grant, version) {
   const params = new URLSearchParams({ grant, version })
   return brokerGet(`/api/version?${params.toString()}`)
 }
+
+/**
+ * Returns the latest active version of a grant configuration.
+ *
+ * @param {string} grant
+ * @returns {Promise<BrokerVersion>}
+ */
+export function fetchLatestActiveVersion(grant) {
+  const params = new URLSearchParams({ grant })
+  return brokerGet(`/api/latestVersion?${params.toString()}`)
+}

--- a/src/modules/config/ingest/broker-client.test.js
+++ b/src/modules/config/ingest/broker-client.test.js
@@ -1,6 +1,6 @@
 import { config } from '../../../config.js'
 import { buildBrokerBearerHeader } from './broker-auth.js'
-import { fetchAllGrants, fetchVersion } from './broker-client.js'
+import { fetchAllGrants, fetchVersion, fetchLatestActiveVersion } from './broker-client.js'
 
 jest.mock('../../../config.js', () => ({
   config: {
@@ -106,6 +106,21 @@ describe('broker-client', () => {
 
       expect(global.fetch).toHaveBeenCalledWith(
         'https://broker.example/api/version?grant=farm-payments&version=1.0.0',
+        expect.any(Object)
+      )
+      expect(result).toEqual(version)
+    })
+  })
+
+  describe('fetchLatestActiveVersion', () => {
+    test('requests the latest active version for a grant', async () => {
+      const version = { grant: 'farm-payments', version: '2.0.0', status: 'active' }
+      global.fetch.mockResolvedValue(okResponse(version))
+
+      const result = await fetchLatestActiveVersion('farm-payments')
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://broker.example/api/latestVersion?grant=farm-payments',
         expect.any(Object)
       )
       expect(result).toEqual(version)

--- a/src/modules/config/ingest/ingest.js
+++ b/src/modules/config/ingest/ingest.js
@@ -1,5 +1,5 @@
 import { upsertDefinition } from '../config.repository.js'
-import { getYamlObject } from './s3-client.js'
+import { getYamlObject } from '../../../common/helpers/s3.js'
 import { buildFormDefinition } from './transform.js'
 import { log, LogCodes } from '../../../common/helpers/logging/log.js'
 

--- a/src/modules/config/ingest/ingest.test.js
+++ b/src/modules/config/ingest/ingest.test.js
@@ -1,6 +1,6 @@
 import { ingestVersion } from './ingest.js'
 import { upsertDefinition } from '../config.repository.js'
-import { getYamlObject } from './s3-client.js'
+import { getYamlObject } from '../../../common/helpers/s3.js'
 import { FORM_DEFINITION_STATUS } from '../config.constants.js'
 import { log, LogCodes } from '../../../common/helpers/logging/log.js'
 
@@ -8,7 +8,7 @@ jest.mock('../config.repository.js', () => ({
   upsertDefinition: jest.fn()
 }))
 
-jest.mock('./s3-client.js', () => ({
+jest.mock('../../../common/helpers/s3.js', () => ({
   getYamlObject: jest.fn()
 }))
 

--- a/src/modules/config/ingest/sqs-consumer.js
+++ b/src/modules/config/ingest/sqs-consumer.js
@@ -1,7 +1,9 @@
 import { SQSClient, ReceiveMessageCommand, DeleteMessageCommand } from '@aws-sdk/client-sqs'
 import { config } from '../../../config.js'
 import { ingestVersion } from './ingest.js'
+import { ingestAllowlist } from '../../allowlist/ingest-allowlist.js'
 import { parseSnsMessage } from './sns-message.js'
+import { FORM_DEFINITION_STATUS } from '../config.constants.js'
 import { log, LogCodes } from '../../../common/helpers/logging/log.js'
 
 /**
@@ -55,6 +57,10 @@ export async function handleMessage(message) {
     bucket,
     manifest
   })
+
+  if (status === FORM_DEFINITION_STATUS.ACTIVE) {
+    await ingestAllowlist({ grantCode, version, bucket, manifest })
+  }
 }
 
 /**

--- a/src/modules/config/ingest/sqs-consumer.test.js
+++ b/src/modules/config/ingest/sqs-consumer.test.js
@@ -1,6 +1,7 @@
 import { SQSClient, ReceiveMessageCommand, DeleteMessageCommand } from '@aws-sdk/client-sqs'
 import { config } from '../../../config.js'
 import { ingestVersion } from './ingest.js'
+import { ingestAllowlist } from '../../allowlist/ingest-allowlist.js'
 import { parseSnsMessage } from './sns-message.js'
 import { handleMessage, sqsConsumerPlugin } from './sqs-consumer.js'
 import { log, LogCodes } from '../../../common/helpers/logging/log.js'
@@ -19,6 +20,10 @@ jest.mock('../../../config.js', () => ({
 
 jest.mock('./ingest.js', () => ({
   ingestVersion: jest.fn()
+}))
+
+jest.mock('../../allowlist/ingest-allowlist.js', () => ({
+  ingestAllowlist: jest.fn()
 }))
 
 jest.mock('./sns-message.js', () => ({
@@ -65,6 +70,33 @@ describe('handleMessage', () => {
       bucket: 'my-bucket',
       manifest: ['farm-payments.yaml']
     })
+  })
+
+  test('ingests allowlist when status is active', async () => {
+    parseSnsMessage.mockReturnValue({
+      attributes: { grant: 'farm-payments', version: '1.0.0', status: 'active', path: 'my-bucket' },
+      manifest: ['farm-payments.yaml']
+    })
+
+    await handleMessage({ Body: 'body' })
+
+    expect(ingestAllowlist).toHaveBeenCalledWith({
+      grantCode: 'farm-payments',
+      version: '1.0.0',
+      bucket: 'my-bucket',
+      manifest: ['farm-payments.yaml']
+    })
+  })
+
+  test('does not ingest allowlist when status is draft', async () => {
+    parseSnsMessage.mockReturnValue({
+      attributes: { grant: 'farm-payments', version: '1.0.0', status: 'draft', path: 'my-bucket' },
+      manifest: ['farm-payments.yaml']
+    })
+
+    await handleMessage({ Body: 'body' })
+
+    expect(ingestAllowlist).not.toHaveBeenCalled()
   })
 
   test.each([

--- a/src/modules/config/ingest/startup-pull.js
+++ b/src/modules/config/ingest/startup-pull.js
@@ -113,6 +113,8 @@ export async function runStartupPull() {
         upserted += 1
       } else if (result === 'failed') {
         failed += 1
+      } else {
+        // skipped — no action needed
       }
     }
   }
@@ -121,7 +123,9 @@ export async function runStartupPull() {
   // Done after the version loop so form definitions are fully up to date first.
   for (const grant of grants) {
     const hasActiveVersion = (grant.versions ?? []).some((v) => v.status === 'active')
-    if (!hasActiveVersion) continue
+    if (!hasActiveVersion) {
+      continue
+    }
 
     try {
       const latestActive = await fetchLatestActiveVersion(grant.grant)

--- a/src/modules/config/ingest/startup-pull.js
+++ b/src/modules/config/ingest/startup-pull.js
@@ -1,6 +1,7 @@
-import { fetchAllGrants, fetchVersion } from './broker-client.js'
+import { fetchAllGrants, fetchVersion, fetchLatestActiveVersion } from './broker-client.js'
 import { ingestVersion } from './ingest.js'
 import { definitionStatusKey, getDefinitionStatuses, updateDefinitionStatus } from '../config.repository.js'
+import { ingestAllowlist } from '../../allowlist/ingest-allowlist.js'
 import { log, LogCodes } from '../../../common/helpers/logging/log.js'
 
 /**
@@ -79,6 +80,8 @@ async function pullVersionSafely(grant, versionSummary, existingStatuses) {
 
 /**
  * Pulls every grant version from the broker and upserts each into Mongo.
+ * After all form definitions are ingested, ingests the allowlist for the
+ * latest active version of each grant.
  *
  * Failures for individual versions are logged but do not abort the rest of
  * the pull — we want the server to come up with as much current data as the
@@ -110,9 +113,31 @@ export async function runStartupPull() {
         upserted += 1
       } else if (result === 'failed') {
         failed += 1
-      } else {
-        // skipped
       }
+    }
+  }
+
+  // Ingest the allowlist for the latest active version of each grant.
+  // Done after the version loop so form definitions are fully up to date first.
+  for (const grant of grants) {
+    const hasActiveVersion = (grant.versions ?? []).some((v) => v.status === 'active')
+    if (!hasActiveVersion) continue
+
+    try {
+      const latestActive = await fetchLatestActiveVersion(grant.grant)
+      await ingestAllowlist({
+        grantCode: latestActive.grant,
+        version: latestActive.version,
+        bucket: latestActive.path,
+        manifest: latestActive.manifest
+      })
+    } catch (err) {
+      log(LogCodes.ALLOWLIST.STARTUP_PULL_FAILED, {
+        grantCode: grant.grant,
+        errorName: err.name,
+        errorMessage: err.message,
+        stack: err.stack
+      })
     }
   }
 

--- a/src/modules/config/ingest/startup-pull.js
+++ b/src/modules/config/ingest/startup-pull.js
@@ -1,6 +1,7 @@
 import { fetchAllGrants, fetchVersion, fetchLatestActiveVersion } from './broker-client.js'
 import { ingestVersion } from './ingest.js'
 import { definitionStatusKey, getDefinitionStatuses, updateDefinitionStatus } from '../config.repository.js'
+import { FORM_DEFINITION_STATUS } from '../config.constants.js'
 import { ingestAllowlist } from '../../allowlist/ingest-allowlist.js'
 import { log, LogCodes } from '../../../common/helpers/logging/log.js'
 
@@ -122,7 +123,7 @@ export async function runStartupPull() {
   // Ingest the allowlist for the latest active version of each grant.
   // Done after the version loop so form definitions are fully up to date first.
   for (const grant of grants) {
-    const hasActiveVersion = (grant.versions ?? []).some((v) => v.status === 'active')
+    const hasActiveVersion = (grant.versions ?? []).some((v) => v.status === FORM_DEFINITION_STATUS.ACTIVE)
     if (!hasActiveVersion) {
       continue
     }

--- a/src/modules/config/ingest/startup-pull.test.js
+++ b/src/modules/config/ingest/startup-pull.test.js
@@ -1,13 +1,19 @@
 import { runStartupPull } from './startup-pull.js'
-import { fetchAllGrants, fetchVersion } from './broker-client.js'
+import { fetchAllGrants, fetchVersion, fetchLatestActiveVersion } from './broker-client.js'
 import { ingestVersion } from './ingest.js'
+import { ingestAllowlist } from '../../allowlist/ingest-allowlist.js'
 import { definitionStatusKey, getDefinitionStatuses, updateDefinitionStatus } from '../config.repository.js'
 import { FORM_DEFINITION_STATUS } from '../config.constants.js'
 import { log, LogCodes } from '../../../common/helpers/logging/log.js'
 
 jest.mock('./broker-client.js', () => ({
   fetchAllGrants: jest.fn(),
-  fetchVersion: jest.fn()
+  fetchVersion: jest.fn(),
+  fetchLatestActiveVersion: jest.fn()
+}))
+
+jest.mock('../../allowlist/ingest-allowlist.js', () => ({
+  ingestAllowlist: jest.fn()
 }))
 
 jest.mock('./ingest.js', () => ({
@@ -149,5 +155,52 @@ describe('runStartupPull', () => {
     const result = await runStartupPull()
 
     expect(result).toEqual({ total: 0, upserted: 0, failed: 0 })
+  })
+
+  test('ingests allowlist for grants with an active version', async () => {
+    fetchAllGrants.mockResolvedValue([
+      { grant: 'woodland', versions: [{ version: '1.0.0', status: FORM_DEFINITION_STATUS.ACTIVE }] }
+    ])
+    fetchLatestActiveVersion.mockResolvedValue({
+      grant: 'woodland',
+      version: '1.0.0',
+      path: 'my-bucket',
+      manifest: ['woodland/1.0.0/woodland.yaml', 'woodland/1.0.0/allowlist.yaml']
+    })
+
+    await runStartupPull()
+
+    expect(fetchLatestActiveVersion).toHaveBeenCalledWith('woodland')
+    expect(ingestAllowlist).toHaveBeenCalledWith({
+      grantCode: 'woodland',
+      version: '1.0.0',
+      bucket: 'my-bucket',
+      manifest: ['woodland/1.0.0/woodland.yaml', 'woodland/1.0.0/allowlist.yaml']
+    })
+  })
+
+  test('skips allowlist ingest for grants with no active versions', async () => {
+    fetchAllGrants.mockResolvedValue([
+      { grant: 'woodland', versions: [{ version: '1.0.0', status: FORM_DEFINITION_STATUS.DRAFT }] }
+    ])
+
+    await runStartupPull()
+
+    expect(fetchLatestActiveVersion).not.toHaveBeenCalled()
+    expect(ingestAllowlist).not.toHaveBeenCalled()
+  })
+
+  test('logs and continues when allowlist ingest fails', async () => {
+    fetchAllGrants.mockResolvedValue([
+      { grant: 'woodland', versions: [{ version: '1.0.0', status: FORM_DEFINITION_STATUS.ACTIVE }] }
+    ])
+    fetchLatestActiveVersion.mockRejectedValue(new Error('broker unavailable'))
+
+    await runStartupPull()
+
+    expect(log).toHaveBeenCalledWith(
+      LogCodes.ALLOWLIST.STARTUP_PULL_FAILED,
+      expect.objectContaining({ grantCode: 'woodland', errorMessage: 'broker unavailable' })
+    )
   })
 })

--- a/src/modules/config/ingest/startup-pull.test.js
+++ b/src/modules/config/ingest/startup-pull.test.js
@@ -165,7 +165,7 @@ describe('runStartupPull', () => {
       grant: 'woodland',
       version: '1.0.0',
       path: 'my-bucket',
-      manifest: ['woodland/1.0.0/woodland.yaml', 'woodland/1.0.0/allowlist.yaml']
+      manifest: ['woodland/1.0.0/grants-ui/woodland.yaml', 'woodland/1.0.0/grants-ui/allowlist.yaml']
     })
 
     await runStartupPull()
@@ -175,7 +175,7 @@ describe('runStartupPull', () => {
       grantCode: 'woodland',
       version: '1.0.0',
       bucket: 'my-bucket',
-      manifest: ['woodland/1.0.0/woodland.yaml', 'woodland/1.0.0/allowlist.yaml']
+      manifest: ['woodland/1.0.0/grants-ui/woodland.yaml', 'woodland/1.0.0/grants-ui/allowlist.yaml']
     })
   })
 

--- a/src/modules/config/ingest/transform.js
+++ b/src/modules/config/ingest/transform.js
@@ -50,6 +50,7 @@ export function buildFormDefinition({ grantCode, version, status, definition, up
     grantCode,
     id: definition?.metadata?.id ?? `${grantCode}@${version}`,
     title: definition?.name ?? grantCode,
+    description: definition?.metadata?.description ?? null,
     major,
     minor,
     patch,

--- a/src/modules/config/ingest/transform.test.js
+++ b/src/modules/config/ingest/transform.test.js
@@ -53,6 +53,7 @@ describe('buildFormDefinition', () => {
       grantCode: 'farm-payments',
       id: 'fd-001',
       title: 'Farm Payments',
+      description: null,
       major: 1,
       minor: 2,
       patch: 3,
@@ -66,6 +67,15 @@ describe('buildFormDefinition', () => {
     const result = buildFormDefinition({ ...baseParams, definition: { name: 'Farm Payments' } })
 
     expect(result.id).toBe('farm-payments@1.2.3')
+  })
+
+  test('extracts description from metadata', () => {
+    const result = buildFormDefinition({
+      ...baseParams,
+      definition: { name: 'Farm Payments', metadata: { id: 'fd-001', description: 'A description.' } }
+    })
+
+    expect(result.description).toBe('A description.')
   })
 
   test('falls back to grantCode for title when definition name is missing', () => {

--- a/src/plugins/auth.js
+++ b/src/plugins/auth.js
@@ -1,5 +1,6 @@
 import Boom from '@hapi/boom'
 import crypto from 'node:crypto'
+import jwt from 'jsonwebtoken'
 import { config } from '../config.js'
 import { log, LogCodes } from '../common/helpers/logging/log.js'
 
@@ -96,6 +97,38 @@ function validateAuthToken(authHeader) {
   return { isValid: true }
 }
 
+/**
+ * Decodes an x-encrypted-auth JWT and returns its claims.
+ * Returns an empty object if the token is absent, the secret is missing,
+ * or verification fails.
+ *
+ * @param {string|undefined} encryptedAuth
+ * @param {string} jwtSecret
+ * @returns {Record<string, unknown>}
+ */
+export function decodeEncryptedAuthHeader(encryptedAuth, jwtSecret) {
+  if (!encryptedAuth) return {}
+
+  if (!jwtSecret) {
+    log(LogCodes.AUTH.TOKEN_VERIFICATION_FAILURE, {
+      errorName: 'JWT secret not configured',
+      errorMessage: 'Cannot decode x-encrypted-auth header — JWT secret is missing'
+    })
+    return {}
+  }
+
+  try {
+    return jwt.verify(encryptedAuth, jwtSecret)
+  } catch (err) {
+    log(LogCodes.AUTH.TOKEN_VERIFICATION_FAILURE, {
+      errorName: err.name,
+      errorMessage: err.message,
+      stack: err.stack
+    })
+    return {}
+  }
+}
+
 const auth = {
   plugin: {
     name: 'auth',
@@ -116,7 +149,13 @@ const auth = {
               method: request.method
             })
 
-            return h.authenticated({ credentials: { authenticated: true } })
+            const jwtSecret = config.get('encryptedAuthJwtSecret')
+            const payload = decodeEncryptedAuthHeader(request.headers['x-encrypted-auth'], jwtSecret)
+            const crn =
+              typeof payload.crn === 'string' || typeof payload.crn === 'number' ? `${payload.crn}` : undefined
+            const sbi =
+              typeof payload.sbi === 'string' || typeof payload.sbi === 'number' ? `${payload.sbi}` : undefined
+            return h.authenticated({ credentials: { authenticated: true, crn, sbi } })
           }
         }
       })

--- a/src/plugins/auth.js
+++ b/src/plugins/auth.js
@@ -107,7 +107,9 @@ function validateAuthToken(authHeader) {
  * @returns {Record<string, unknown>}
  */
 export function decodeEncryptedAuthHeader(encryptedAuth, jwtSecret) {
-  if (!encryptedAuth) return {}
+  if (!encryptedAuth) {
+    return {}
+  }
 
   if (!jwtSecret) {
     log(LogCodes.AUTH.TOKEN_VERIFICATION_FAILURE, {

--- a/src/plugins/decode-user-identity.test.js
+++ b/src/plugins/decode-user-identity.test.js
@@ -87,3 +87,23 @@ describe('decodeEncryptedAuthHeader', () => {
     expect(result).not.toHaveProperty('sbi')
   })
 })
+
+describe('decodeEncryptedAuthHeader — existing endpoint compatibility', () => {
+  test('returns empty object when x-encrypted-auth header is absent, leaving existing endpoints unaffected', () => {
+    // Existing endpoints (/state/*, /health, etc.) do not send x-encrypted-auth.
+    // decodeEncryptedAuthHeader must return {} so credentials.crn and credentials.sbi
+    // remain undefined and the authenticate function still calls h.authenticated() normally.
+    const result = decodeEncryptedAuthHeader(undefined, SECRET)
+
+    expect(result).toEqual({})
+  })
+
+  test('crn and sbi are undefined when x-encrypted-auth is absent', () => {
+    const payload = decodeEncryptedAuthHeader(undefined, SECRET)
+    const crn = typeof payload.crn === 'string' || typeof payload.crn === 'number' ? `${payload.crn}` : undefined
+    const sbi = typeof payload.sbi === 'string' || typeof payload.sbi === 'number' ? `${payload.sbi}` : undefined
+
+    expect(crn).toBeUndefined()
+    expect(sbi).toBeUndefined()
+  })
+})

--- a/src/plugins/decode-user-identity.test.js
+++ b/src/plugins/decode-user-identity.test.js
@@ -1,0 +1,89 @@
+import jwt from 'jsonwebtoken'
+import { decodeEncryptedAuthHeader } from './auth.js'
+
+jest.mock('../common/helpers/logging/log.js', () => {
+  const { LogCodes } = jest.requireActual('../common/helpers/logging/log-codes.js')
+  return { log: jest.fn(), LogCodes }
+})
+
+import { log, LogCodes } from '../common/helpers/logging/log.js'
+
+const SECRET = 'test-secret'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('decodeEncryptedAuthHeader', () => {
+  test('returns payload from a valid JWT', () => {
+    const token = jwt.sign({ crn: '1234567890', sbi: '123456789' }, SECRET)
+
+    const result = decodeEncryptedAuthHeader(token, SECRET)
+
+    expect(result).toMatchObject({ crn: '1234567890', sbi: '123456789' })
+  })
+
+  test('numeric claims are preserved as-is in the raw payload', () => {
+    const token = jwt.sign({ crn: 1234567890, sbi: 123456789 }, SECRET)
+
+    const result = decodeEncryptedAuthHeader(token, SECRET)
+
+    expect(result).toMatchObject({ crn: 1234567890, sbi: 123456789 })
+  })
+
+  test('returns empty object when header is absent', () => {
+    expect(decodeEncryptedAuthHeader(undefined, SECRET)).toEqual({})
+    expect(log).not.toHaveBeenCalled()
+  })
+
+  test('returns empty object and logs when jwtSecret is not provided', () => {
+    const token = jwt.sign({ crn: '1234567890', sbi: '123456789' }, SECRET)
+
+    const result = decodeEncryptedAuthHeader(token, '')
+
+    expect(result).toEqual({})
+    expect(log).toHaveBeenCalledWith(
+      LogCodes.AUTH.TOKEN_VERIFICATION_FAILURE,
+      expect.objectContaining({
+        errorName: 'JWT secret not configured'
+      })
+    )
+  })
+
+  test('returns empty object and logs when token signature is invalid', () => {
+    const token = jwt.sign({ crn: '1234567890', sbi: '123456789' }, 'wrong-secret')
+
+    const result = decodeEncryptedAuthHeader(token, SECRET)
+
+    expect(result).toEqual({})
+    expect(log).toHaveBeenCalledWith(
+      LogCodes.AUTH.TOKEN_VERIFICATION_FAILURE,
+      expect.objectContaining({
+        errorName: 'JsonWebTokenError'
+      })
+    )
+  })
+
+  test('returns empty object and logs when token is expired', () => {
+    const token = jwt.sign({ crn: '1234567890', sbi: '123456789' }, SECRET, { expiresIn: -1 })
+
+    const result = decodeEncryptedAuthHeader(token, SECRET)
+
+    expect(result).toEqual({})
+    expect(log).toHaveBeenCalledWith(
+      LogCodes.AUTH.TOKEN_VERIFICATION_FAILURE,
+      expect.objectContaining({
+        errorName: 'TokenExpiredError'
+      })
+    )
+  })
+
+  test('returns payload without crn/sbi when claims are missing from token', () => {
+    const token = jwt.sign({ sub: 'user' }, SECRET)
+
+    const result = decodeEncryptedAuthHeader(token, SECRET)
+
+    expect(result).not.toHaveProperty('crn')
+    expect(result).not.toHaveProperty('sbi')
+  })
+})

--- a/src/plugins/decode-user-identity.test.js
+++ b/src/plugins/decode-user-identity.test.js
@@ -90,9 +90,6 @@ describe('decodeEncryptedAuthHeader', () => {
 
 describe('decodeEncryptedAuthHeader — existing endpoint compatibility', () => {
   test('returns empty object when x-encrypted-auth header is absent, leaving existing endpoints unaffected', () => {
-    // Existing endpoints (/state/*, /health, etc.) do not send x-encrypted-auth.
-    // decodeEncryptedAuthHeader must return {} so credentials.crn and credentials.sbi
-    // remain undefined and the authenticate function still calls h.authenticated() normally.
     const result = decodeEncryptedAuthHeader(undefined, SECRET)
 
     expect(result).toEqual({})

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -2,6 +2,7 @@ import { health } from '../routes/health.js'
 import { applicationLockRelease, applicationLocksRelease } from '../modules/state/locks.routes.js'
 import { stateSave, stateRetrieve, stateDelete, statePatch } from '../modules/state/state.routes.js'
 import { addSubmission, retrieveSubmissions } from '../modules/state/submissions.routes.js'
+import { allowlistGrants } from '../modules/allowlist/allowlist.routes.js'
 
 const router = {
   plugin: {
@@ -16,7 +17,8 @@ const router = {
         retrieveSubmissions,
         statePatch,
         applicationLockRelease,
-        applicationLocksRelease
+        applicationLocksRelease,
+        allowlistGrants
       ])
     }
   }

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,7 @@ import { requestLogger } from './common/helpers/logging/request-logger.js'
 import { mongoDb } from './common/helpers/mongodb.js'
 import { initStateRepository } from './modules/state/state.repository.js'
 import { initConfigRepository } from './modules/config/config.repository.js'
+import { initAllowlistRepository } from './modules/allowlist/allowlist.repository.js'
 import { failAction } from './common/helpers/fail-action.js'
 import { secureContext } from './common/helpers/secure-context/index.js'
 import { pulse } from './common/helpers/pulse.js'
@@ -88,6 +89,7 @@ async function createServer() {
   // server.stateDb / server.configDb decorations are available.
   initStateRepository(server.stateDb)
   initConfigRepository(server.configDb)
+  initAllowlistRepository(server.configDb)
 
   return server
 }


### PR DESCRIPTION
**Add allowlist endpoint — GET /allowlist/grants**

Introduces a self-contained allowlist module that serves as a single source of truth for which users can access which grants, and what those grants look like (title, description, URL). Replaces the need for SFD/journeys to maintain their own hard-coded grant whitelists.

**What's in the PR:**

- GET /allowlist/grants — returns the grants a user is permitted to access, identified by CRN + SBI passed as claims in a signed JWT (x-encrypted-auth header, verified with ENCRYPTED_AUTH_JWT_SECRET)
- Allowlist ingestion from allowlist.yaml in the grant config, triggered on startup and on SQS messages when a version becomes active. Uses MongoDB transactions to atomically replace entries per grant
- Removing an existing allowlist.yaml from grant config will cause the grant to close to all users, being that grant hidden for every sbi/crn requested.
- Ability to open an entire grant by using allowAll flag (documented).
- The allowlist used will always be the latest ACTIVE version uploaded for a grant.
- Per-user LRU cache (TTL 2 min, max 500 entries) to absorb the two-consumer call pattern (SFD + Grants UI gate check) without hitting MongoDB twice per user journey
- MongoDB migration for allowlist collection indexes
- ENCRYPTED_AUTH_JWT_SECRET config key for the shared JWT secret
- Auth: same encrypted bearer token as all other endpoints. CRN/SBI travel in the JWT header, not the URL or body, keeping PII out of logs.