### PR TITLE
TGC-1459: Prepare repository for AI assistance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ globalConfig.json
 # Pact files are published/fetched via the Pact Broker in CI
 contracts/pacts
 /localstack/config-broker-local/
+AGENTS.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+Application code lives in `src/`. Configuration is in `src/config.js`, plugins are under `src/plugins/`, routes are under `src/routes/`, migrations are in `src/migrations/`, and shared test helpers are in `src/test-helpers/`. Tests are colocated as `*.test.js`.
+
+## Build, Test, and Development Commands
+
+- `npm install`: install dependencies and set up Husky.
+- `npm run dev`: run the backend in development mode.
+- `npm start`: start the production server.
+- `npm test`: run the test suite.
+- `npm run lint` / `npm run lint:fix`: check or fix linting.
+- `npm run format:check` / `npm run format`: check or apply formatting when available.
+
+## Coding Style & Naming Conventions
+
+Use ES modules and the local lint/format settings. Keep route, plugin, migration, and helper names descriptive, and preserve existing auth/header terminology when touching request contracts.
+
+## Domain Language
+
+Use `CONTEXT.md` as the source of truth for Grants UI Backend persistence and identity language. Prefer those terms in APIs, tests, docs, and generated changes.
+
+## Developer Addenda
+
+Developers can add their own `AGENTS.local.md` and should be read as an addendum to this file. Keep that file local to your machine and do not commit it.
+
+## Testing Guidelines
+
+Add or update colocated unit tests for route, plugin, and migration changes. Run the narrowest relevant test first, then broader test and lint commands.
+
+## Security & Configuration Tips
+
+Do not commit secrets, private HTTP client files, or local database credentials. Generated Pact files and localstack artifacts should remain disposable.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,45 @@
+# grants-ui-backend
+
+The persistence API used by Grants UI to save, fetch, and migrate grant application state.
+
+## Language
+
+**Grants UI Backend**
+The persistence API used by Grants UI to store and retrieve form state.
+_Avoid_: GAS, Config API, Redis
+
+**Application state**
+The saved answers, identifiers, status, and metadata for a user's grant application.
+_Avoid_: Session data when persisted backend state is meant, Form definition
+
+**Form state**
+The persisted representation of answers and progress for a grant journey.
+_Avoid_: Browser state, Configuration, Payload when the stored state is meant
+
+**Migration**
+A backend data change that updates existing persisted application state or indexes.
+_Avoid_: Release, Seed script, Feature flag
+
+**Reference number**
+The user-facing identifier for a submitted application.
+_Avoid_: Grant code, Slug, Session ID
+
+**Client reference**
+The reference used when querying or submitting an application to downstream services.
+_Avoid_: Reference number when discussing display, Case ID
+
+**CRN**
+Customer Reference Number: the Defra ID identifier for an individual user.
+_Avoid_: SBI, User ID, Account number
+
+**SBI**
+Single Business Identifier: the farm business or organisation represented by the signed-in user.
+_Avoid_: CRN, Business name, Holding number
+
+**Lock token**
+A token used to coordinate exclusive access to mutable application state.
+_Avoid_: Auth token, Session token, CSRF token
+
+**Pact**
+The contract-test artifact used to verify API expectations with consumers or providers.
+_Avoid_: Unit test, Schema, Mock response


### PR DESCRIPTION
## Summary

- Add repository guidance for AI coding agents in `AGENTS.md`.
- Add `CONTEXT.md` as the source of truth for domain language where needed.
- Ignore local-only `AGENTS.local.md` addenda without creating that file.
