### PR TITLE
Add DELETE /admin/test-data endpoint

### DIFF
--- a/src/common/helpers/logging/log-codes.js
+++ b/src/common/helpers/logging/log-codes.js
@@ -179,6 +179,23 @@ export const LogCodes = {
         `Failed to add submission | crn=${messageOptions.crn} | sbi=${messageOptions.sbi} | grantCode=${messageOptions.grantCode} | grantVersion=${messageOptions.grantVersion} | referenceNumber=${messageOptions.referenceNumber} | previousReferenceNumber=${messageOptions.previousReferenceNumber} | submittedAt=${messageOptions.submittedAt} | errorName=${messageOptions.errorName} | errorMessage=${messageOptions.errorMessage} | errorReason=${messageOptions.errorReason} | errorCode=${messageOptions.errorCode} | isMongoError=${messageOptions.isMongoError} | stack=${messageOptions.stack}`
     }
   },
+  TEST_DATA: {
+    CLEARED: {
+      level: 'info',
+      messageFunc: ({ sbi, grantCode, stateDeletedCount, submissionsDeletedCount, locksDeletedCount }) =>
+        `Cleared test data | sbi=${sbi} | grantCode=${grantCode} | stateDeletedCount=${stateDeletedCount} | submissionsDeletedCount=${submissionsDeletedCount} | locksDeletedCount=${locksDeletedCount}`
+    },
+    CLEAR_FAILED: {
+      level: 'error',
+      messageFunc: (messageOptions) =>
+        `Failed to clear test data | sbi=${messageOptions.sbi} | grantCode=${messageOptions.grantCode} | errorName=${messageOptions.errorName} | errorMessage=${messageOptions.errorMessage} | errorReason=${messageOptions.errorReason} | errorCode=${messageOptions.errorCode} | isMongoError=${messageOptions.isMongoError} | stack=${messageOptions.stack}`
+    },
+    CLEAR_FORBIDDEN: {
+      level: 'warn',
+      messageFunc: ({ sbi, grantCode, cdpEnvironment }) =>
+        `Rejected test-data clear outside permitted environments | sbi=${sbi} | grantCode=${grantCode} | cdpEnvironment=${cdpEnvironment}`
+    }
+  },
   CONFIG: {
     INGEST_MISSING_PARAMS: {
       level: 'error',

--- a/src/modules/state/state.repository.js
+++ b/src/modules/state/state.repository.js
@@ -490,6 +490,81 @@ export async function findUnsubmittedApplicationStates({ grantCode }) {
 }
 
 /**
+ * Deletes all application state documents for an (sbi, grantCode) pair, across every grantVersion.
+ *
+ * @param {{ sbi: string, grantCode: string }} params
+ * @returns {Promise<import('mongodb').DeleteResult>}
+ */
+export async function deleteAllApplicationStatesForGrant({ sbi, grantCode }) {
+  try {
+    return await stateDb.collection(STATE_COLLECTION).deleteMany({ sbi, grantCode })
+  } catch (err) {
+    const isMongoError = err?.name?.startsWith('Mongo')
+    log(LogCodes.STATE.STATE_DELETE_FAILED, {
+      sbi,
+      grantCode,
+      errorName: err.name,
+      errorMessage: err.message,
+      errorReason: err.reason,
+      errorCode: err.code,
+      isMongoError,
+      stack: err.stack?.split('\n')[0]
+    })
+    throw err
+  }
+}
+
+/**
+ * Deletes all submission records for an (sbi, grantCode) pair.
+ *
+ * @param {{ sbi: string, grantCode: string }} params
+ * @returns {Promise<import('mongodb').DeleteResult>}
+ */
+export async function deleteAllSubmissionsForGrant({ sbi, grantCode }) {
+  try {
+    return await stateDb.collection(SUBMISSIONS_COLLECTION).deleteMany({ sbi, grantCode })
+  } catch (err) {
+    const isMongoError = err?.name?.startsWith('Mongo')
+    log(LogCodes.SUBMISSIONS.SUBMISSIONS_RETRIEVE_FAILED, {
+      sbi,
+      grantCode,
+      errorName: err.name,
+      errorMessage: err.message,
+      errorReason: err.reason,
+      errorCode: err.code,
+      isMongoError,
+      stack: err.stack?.split('\n')[0]
+    })
+    throw err
+  }
+}
+
+/**
+ * Deletes all application locks for an (sbi, grantCode) pair, across every grantVersion.
+ *
+ * @param {{ sbi: string, grantCode: string }} params
+ * @returns {Promise<import('mongodb').DeleteResult>}
+ */
+export async function deleteAllApplicationLocksForGrant({ sbi, grantCode }) {
+  try {
+    return await stateDb.collection(LOCKS_COLLECTION).deleteMany({ sbi, grantCode })
+  } catch (err) {
+    const isMongoError = err?.name?.startsWith('Mongo')
+    log(LogCodes.APPLICATION_LOCK.RELEASE_FAILED, {
+      sbi,
+      grantCode,
+      errorName: err.name,
+      errorMessage: err.message,
+      errorReason: err.reason,
+      errorCode: err.code,
+      isMongoError,
+      stack: err.stack?.split('\n')[0]
+    })
+    throw err
+  }
+}
+
+/**
  * Purges application states for a given grantCode by marking them as PURGED.
  *
  * @param {import('mongodb').ObjectId[]} ids

--- a/src/modules/state/state.schema.js
+++ b/src/modules/state/state.schema.js
@@ -114,3 +114,10 @@ export const applicationLockReleaseSchema = Joi.object({
   grantCode: Joi.string().required(),
   grantVersion: grantVersion().required()
 })
+
+// --- admin/test-data route ---
+
+export const clearTestDataSchema = Joi.object({
+  sbi: Joi.string().required(),
+  grantCode: Joi.string().required()
+})

--- a/src/modules/state/state.service.js
+++ b/src/modules/state/state.service.js
@@ -25,7 +25,10 @@ import {
   getLatestApplicationStateForGrant as repoGetLatestApplicationStateForGrant,
   updateApplicationStateVersion as repoUpdateApplicationStateVersion,
   findUnsubmittedApplicationStates as repoFindUnsubmittedApplicationStates,
-  purgeApplicationStates as repoPurgeApplicationStates
+  purgeApplicationStates as repoPurgeApplicationStates,
+  deleteAllApplicationStatesForGrant as repoDeleteAllApplicationStatesForGrant,
+  deleteAllSubmissionsForGrant as repoDeleteAllSubmissionsForGrant,
+  deleteAllApplicationLocksForGrant as repoDeleteAllApplicationLocksForGrant
 } from './state.repository.js'
 import { resolveLatestVersion, resolveLatestVersionWithinMajor } from '../config/config.service.js'
 import { log, LogCodes } from '../../common/helpers/logging/log.js'
@@ -308,4 +311,28 @@ export async function purgeApplications({ grantCode, versionRule }) {
   const result = await repoPurgeApplicationStates(idsToPurge)
 
   return result.modifiedCount
+}
+
+/**
+ * Deletes all test data for an (sbi, grantCode) pair: application state, submissions,
+ * and application locks, across every grantVersion.
+ *
+ * Intended for use by automated test suites to reset a known test SBI/grantCode
+ * between runs; not exposed outside non-production environments.
+ *
+ * @param {{ sbi: string, grantCode: string }} params
+ * @returns {Promise<{ stateDeletedCount: number, submissionsDeletedCount: number, locksDeletedCount: number }>}
+ */
+export async function clearTestData({ sbi, grantCode }) {
+  const [stateResult, submissionsResult, locksResult] = await Promise.all([
+    repoDeleteAllApplicationStatesForGrant({ sbi, grantCode }),
+    repoDeleteAllSubmissionsForGrant({ sbi, grantCode }),
+    repoDeleteAllApplicationLocksForGrant({ sbi, grantCode })
+  ])
+
+  return {
+    stateDeletedCount: stateResult.deletedCount,
+    submissionsDeletedCount: submissionsResult.deletedCount,
+    locksDeletedCount: locksResult.deletedCount
+  }
 }

--- a/src/modules/state/state.service.test.js
+++ b/src/modules/state/state.service.test.js
@@ -10,7 +10,8 @@ import {
   insertSubmission,
   findSubmissions,
   getStateWithFormDefinition,
-  purgeApplications
+  purgeApplications,
+  clearTestData
 } from './state.service'
 import { initStateRepository } from './state.repository'
 import { resolveLatestVersion, resolveLatestVersionWithinMajor } from '../config/config.service.js'
@@ -651,5 +652,66 @@ describe('purgeApplications', () => {
         versionRule: '<2.0.0'
       })
     ).rejects.toThrow('db exploded')
+  })
+})
+
+describe('clearTestData', () => {
+  let server
+
+  beforeAll(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop({ timeout: 0 })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    initStateRepository(server.stateDb)
+  })
+
+  test('deletes state, submissions, and locks for the given sbi/grantCode and reports counts', async () => {
+    const deleteManyCalls = []
+    const fakeDb = {
+      collection: (name) => ({
+        deleteMany: (filter) => {
+          deleteManyCalls.push({ name, filter })
+          return { deletedCount: name === 'state__grant_application_state' ? 2 : 1 }
+        }
+      })
+    }
+
+    initStateRepository(fakeDb)
+
+    const result = await clearTestData({ sbi: '123456789', grantCode: 'EGWA' })
+
+    expect(deleteManyCalls).toEqual(
+      expect.arrayContaining([
+        { name: 'state__grant_application_state', filter: { sbi: '123456789', grantCode: 'EGWA' } },
+        { name: 'state__grant_application_submissions', filter: { sbi: '123456789', grantCode: 'EGWA' } },
+        { name: 'state__grant_application_locks', filter: { sbi: '123456789', grantCode: 'EGWA' } }
+      ])
+    )
+    expect(result).toEqual({
+      stateDeletedCount: 2,
+      submissionsDeletedCount: 1,
+      locksDeletedCount: 1
+    })
+  })
+
+  test('re-throws when a repository call fails', async () => {
+    const fakeDb = {
+      collection: () => ({
+        deleteMany: () => {
+          throw new Error('db exploded')
+        }
+      })
+    }
+
+    initStateRepository(fakeDb)
+
+    await expect(clearTestData({ sbi: '123456789', grantCode: 'EGWA' })).rejects.toThrow('db exploded')
   })
 })

--- a/src/modules/state/test-data.routes.js
+++ b/src/modules/state/test-data.routes.js
@@ -1,0 +1,72 @@
+import Boom from '@hapi/boom'
+import { StatusCodes } from 'http-status-codes'
+import { config } from '../../config.js'
+import { log, LogCodes } from '../../common/helpers/logging/log.js'
+import { clearTestDataSchema } from './state.schema.js'
+import { clearTestData } from './state.service.js'
+
+// Environments where automated test suites run and destructive-by-SBI cleanup is safe.
+const TEST_DATA_CLEAR_ALLOWED_ENVIRONMENTS = new Set(['local', 'dev', 'test', 'perf-test', 'ext-test'])
+
+export const clearTestDataRoute = {
+  method: 'DELETE',
+  path: '/admin/test-data',
+  options: {
+    auth: 'bearer',
+    validate: {
+      query: clearTestDataSchema,
+      failAction: (request, _h, err) => {
+        const { sbi, grantCode } = request.query
+        log(LogCodes.TEST_DATA.CLEAR_FAILED, {
+          sbi,
+          grantCode,
+          errorName: err.name,
+          errorMessage: `DELETE /admin/test-data, validation failed: ${err.message}`,
+          errorReason: err.reason,
+          errorCode: err.code,
+          isMongoError: false,
+          stack: err.stack?.split('\n')[0]
+        })
+        throw err
+      }
+    }
+  },
+  handler: async (request, h) => {
+    const { sbi, grantCode } = request.query
+    const cdpEnvironment = config.get('cdpEnvironment')
+
+    if (!TEST_DATA_CLEAR_ALLOWED_ENVIRONMENTS.has(cdpEnvironment)) {
+      log(LogCodes.TEST_DATA.CLEAR_FORBIDDEN, { sbi, grantCode, cdpEnvironment })
+      throw Boom.forbidden('Test data clear-down is not permitted in this environment')
+    }
+
+    try {
+      const result = await clearTestData({ sbi, grantCode })
+
+      log(LogCodes.TEST_DATA.CLEARED, {
+        sbi,
+        grantCode,
+        stateDeletedCount: result.stateDeletedCount,
+        submissionsDeletedCount: result.submissionsDeletedCount,
+        locksDeletedCount: result.locksDeletedCount
+      })
+
+      return h.response({ success: true, ...result }).code(StatusCodes.OK)
+    } catch (err) {
+      const isMongoError = err?.name?.startsWith('Mongo')
+
+      log(LogCodes.TEST_DATA.CLEAR_FAILED, {
+        sbi,
+        grantCode,
+        errorName: err.name,
+        errorMessage: err.message,
+        errorReason: err.reason,
+        errorCode: err.code,
+        isMongoError,
+        stack: err.stack?.split('\n')[0]
+      })
+
+      return h.response({ error: 'Failed to clear test data' }).code(StatusCodes.INTERNAL_SERVER_ERROR)
+    }
+  }
+}

--- a/src/modules/state/test-data.routes.test.js
+++ b/src/modules/state/test-data.routes.test.js
@@ -1,0 +1,133 @@
+import { clearTestDataRoute } from './test-data.routes.js'
+import { log, LogCodes } from '~/src/common/helpers/logging/log.js'
+import { clearTestData } from './state.service.js'
+import { config } from '~/src/config.js'
+
+jest.mock('~/src/common/helpers/logging/log.js', () => {
+  const { LogCodes } = jest.requireActual('~/src/common/helpers/logging/log-codes.js')
+  return { log: jest.fn(), LogCodes }
+})
+jest.mock('./state.service.js', () => ({
+  clearTestData: jest.fn()
+}))
+jest.mock('~/src/config.js', () => ({
+  config: { get: jest.fn() }
+}))
+
+const createMockH = () => {
+  const response = {
+    code: jest.fn().mockReturnThis()
+  }
+  return {
+    response: jest.fn(() => response)
+  }
+}
+
+const createMockRequest = (overrides = {}) => ({
+  query: {
+    sbi: '123456789',
+    grantCode: 'GRANT1'
+  },
+  ...overrides
+})
+
+describe('clearTestDataRoute', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    config.get.mockReturnValue('test')
+  })
+
+  it('clears test data and returns deleted counts when environment is permitted', async () => {
+    clearTestData.mockResolvedValue({
+      stateDeletedCount: 2,
+      submissionsDeletedCount: 1,
+      locksDeletedCount: 1
+    })
+
+    const request = createMockRequest()
+    const h = createMockH()
+
+    const result = await clearTestDataRoute.handler(request, h)
+
+    expect(clearTestData).toHaveBeenCalledWith({ sbi: '123456789', grantCode: 'GRANT1' })
+    expect(h.response).toHaveBeenCalledWith({
+      success: true,
+      stateDeletedCount: 2,
+      submissionsDeletedCount: 1,
+      locksDeletedCount: 1
+    })
+    expect(result.code).toHaveBeenCalledWith(200)
+  })
+
+  it('throws Boom 403 when cdpEnvironment is prod', async () => {
+    config.get.mockReturnValue('prod')
+
+    const request = createMockRequest()
+    const h = createMockH()
+
+    await expect(clearTestDataRoute.handler(request, h)).rejects.toMatchObject({
+      isBoom: true,
+      output: { statusCode: 403 }
+    })
+    expect(clearTestData).not.toHaveBeenCalled()
+  })
+
+  it.each(['local', 'dev', 'test', 'perf-test', 'ext-test'])('permits clearing in %s environment', async (env) => {
+    config.get.mockReturnValue(env)
+    clearTestData.mockResolvedValue({
+      stateDeletedCount: 0,
+      submissionsDeletedCount: 0,
+      locksDeletedCount: 0
+    })
+
+    const request = createMockRequest()
+    const h = createMockH()
+
+    await clearTestDataRoute.handler(request, h)
+
+    expect(clearTestData).toHaveBeenCalledWith({ sbi: '123456789', grantCode: 'GRANT1' })
+  })
+
+  it('returns 500 when clearTestData throws', async () => {
+    const err = new Error('Mongo exploded')
+    err.code = 123
+    err.reason = 'boom'
+
+    clearTestData.mockRejectedValue(err)
+
+    const request = createMockRequest()
+    const h = createMockH()
+
+    const result = await clearTestDataRoute.handler(request, h)
+
+    expect(h.response).toHaveBeenCalledWith({
+      error: 'Failed to clear test data'
+    })
+    expect(result.code).toHaveBeenCalledWith(500)
+  })
+
+  it('logs and throws on validation failure (failAction)', async () => {
+    const badRequest = {
+      query: {
+        // missing sbi
+        grantCode: 'GRANT1'
+      }
+    }
+
+    const schema = clearTestDataRoute.options.validate.query
+    const { error } = schema.validate(badRequest.query)
+
+    expect(error).toBeInstanceOf(Error)
+
+    expect(() => clearTestDataRoute.options.validate.failAction(badRequest, {}, error)).toThrow()
+
+    expect(log).toHaveBeenCalledWith(
+      LogCodes.TEST_DATA.CLEAR_FAILED,
+      expect.objectContaining({
+        grantCode: 'GRANT1',
+        errorName: error.name,
+        errorMessage: expect.stringContaining('validation failed')
+      })
+    )
+  })
+})

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -9,6 +9,7 @@ import {
 } from '../modules/state/state.routes.js'
 import { addSubmission, retrieveSubmissions } from '../modules/state/submissions.routes.js'
 import { allowlistGrants } from '../modules/allowlist/allowlist.routes.js'
+import { clearTestDataRoute } from '../modules/state/test-data.routes.js'
 
 const router = {
   plugin: {
@@ -25,7 +26,8 @@ const router = {
         statePatch,
         applicationLockRelease,
         applicationLocksRelease,
-        allowlistGrants
+        allowlistGrants,
+        clearTestDataRoute
       ])
     }
   }


### PR DESCRIPTION
Due to the inaccessibility of the `grants-ui-backend` Mongo database to test suites running in CDP we use multiple calls to `grants-ui-backend` endpoints from journey tests to clear down test data. Now we have added `grantVersion` to the parameters this has become less reliable, particularly during our weekly releases as the grant config versions change frequently and we do not clear down the previous state on the first run reliably. This ticket introduces a straightforward test data deletion endpoint that works on all non-prod environments for use with a given SBI and grantCode from a journey or performance test suite.